### PR TITLE
Make actions always run on PRs or pushes

### DIFF
--- a/.github/workflows/cargo_clippy.yml
+++ b/.github/workflows/cargo_clippy.yml
@@ -2,13 +2,9 @@ name: Rust Clippy Check
 
 on:
     pull_request:
-        paths:
-            - 'datagen/**'
         branches:
             - '*'
     push:
-        paths:
-            - 'datagen/**'
         branches:
             - main
 

--- a/.github/workflows/cargo_fmt.yml
+++ b/.github/workflows/cargo_fmt.yml
@@ -2,13 +2,9 @@ name: Rust Format Check
 
 on:
     pull_request:
-        paths:
-            - 'datagen/**'
         branches:
             - '*'
     push:
-        paths:
-            - 'datagen/**'
         branches:
             - main
 

--- a/.github/workflows/cargo_test.yml
+++ b/.github/workflows/cargo_test.yml
@@ -2,13 +2,9 @@ name: Rust Run Tests
 
 on:
     pull_request:
-        paths:
-            - 'datagen/**'
         branches:
             - '*'
     push:
-        paths:
-            - 'datagen/**'
         branches:
             - main
 

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,12 +1,12 @@
 name: ESLint Check
 
-on: 
+on:
   pull_request:
-    branches: '*'
-    paths:
-      - 'site/**'  # This ensures the action runs only for changes in the 'site' directory
+      branches:
+          - '*'
   push:
-    branches: main
+      branches:
+          - main
 
 jobs:
   lint:


### PR DESCRIPTION
I think actions need to always run on PRs or pushes because if they don't, a merge could be failing a CI test, then another commit could be made to that merge and that job wouldn't run again, meaning it would no longer fail it even though it should.