### PR TITLE
Add ratings to info panel, adjustments to mobile UI

### DIFF
--- a/site/src/components/course-planner/course-search/CourseSearch.svelte
+++ b/site/src/components/course-planner/course-search/CourseSearch.svelte
@@ -9,7 +9,6 @@ Copyright (C) 2024 Andrew Cupps
     import CourseListing from "./CourseListing.svelte";
     import { 
         getCourseLookup, 
-        getProfsLookup, 
         searchCourses 
     } from "../../../lib/course-planner/CourseSearch";
     import { appendHoveredSection } from "../../../lib/course-planner/Schedule";
@@ -20,7 +19,6 @@ Copyright (C) 2024 Andrew Cupps
     // Load profs and depts data
     export let data;
     let depts: Department[] = data.departments;
-    let professors: Professor[] = data.professors;
 
     // Create course lookup table
     const courseLookup = getCourseLookup(depts);
@@ -37,8 +35,7 @@ Copyright (C) 2024 Andrew Cupps
                             });
     }
 
-    // Create a professor lookup table
-    const profsLookup = getProfsLookup(professors);
+    export let profsLookup: Record<string, Professor>;
 
     // Boolean for toggling search menu on smaller screens
     export let courseSearchSelected: boolean = false;

--- a/site/src/components/course-planner/course-search/SectionListing.svelte
+++ b/site/src/components/course-planner/course-search/SectionListing.svelte
@@ -101,8 +101,8 @@ Copyright (C) 2024 Andrew Cupps
             class='flex flex-row w-full text-left border-t-2 
                     border-outlineLight dark:border-outlineDark transition
                 {sectionAdded ? 'bg-hoverLight dark:bg-hoverDark' : ''}'
-            class:hover:bg-hoverLight={!profsHover}
-            class:hover:dark:bg-hoverDark={!profsHover}
+            class:lg:hover:bg-hoverLight={!profsHover}
+            class:lg:hover:dark:bg-hoverDark={!profsHover}
         title='Add course to schedule'
                 >
     <!-- Section code -->

--- a/site/src/components/course-planner/course-search/SectionListing.svelte
+++ b/site/src/components/course-planner/course-search/SectionListing.svelte
@@ -5,6 +5,7 @@ https://github.com/atcupps/Jupiterp/LICENSE).
 Copyright (C) 2024 Andrew Cupps
 -->
 <script lang="ts">
+    import { onMount } from "svelte";
     import InstructorListing from "./InstructorListing.svelte";
     import MeetingListing from "./MeetingListing.svelte";
 
@@ -91,13 +92,22 @@ Copyright (C) 2024 Andrew Cupps
     }
 
     let profsHover: boolean = false;
+
+    let isDesktop: boolean = true;
+    let innerWidth: number;
+    $: if (innerWidth) {
+        isDesktop = innerWidth >= 1024;
+        console.log(isDesktop);
+    }
 </script>
+
+<svelte:window bind:innerWidth />
 
 <!-- Ignoring a11y for mouseover because it's a non-essential feature -->
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <button on:click={addSectionToSchedule}
-        on:mouseover={addHoverSection}
-        on:mouseout={removeHoverSection}
+        on:mouseover={isDesktop ? addHoverSection : null}
+        on:mouseout={isDesktop ? removeHoverSection : null}
             class='flex flex-row w-full text-left border-t-2 
                     border-outlineLight dark:border-outlineDark transition
                 {sectionAdded ? 'bg-hoverLight dark:bg-hoverDark' : ''}'

--- a/site/src/components/course-planner/course-search/SectionListing.svelte
+++ b/site/src/components/course-planner/course-search/SectionListing.svelte
@@ -98,7 +98,6 @@ Copyright (C) 2024 Andrew Cupps
     let innerWidth: number;
     $: if (innerWidth) {
         isDesktop = innerWidth >= 1024;
-        console.log(isDesktop);
     }
 </script>
 
@@ -109,7 +108,7 @@ Copyright (C) 2024 Andrew Cupps
 <button on:click={addSectionToSchedule}
         on:mouseover={isDesktop ? addHoverSection : null}
         on:mouseout={isDesktop ? removeHoverSection : null}
-            class='flex flex-row w-full text-left border-t-2 
+            class='flex flex-row w-full text-left border-t-2
                     border-outlineLight dark:border-outlineDark transition
                 {sectionAdded ? 'bg-hoverLight dark:bg-hoverDark' : ''}'
             class:lg:hover:bg-hoverLight={!profsHover}

--- a/site/src/components/course-planner/course-search/SectionListing.svelte
+++ b/site/src/components/course-planner/course-search/SectionListing.svelte
@@ -5,7 +5,6 @@ https://github.com/atcupps/Jupiterp/LICENSE).
 Copyright (C) 2024 Andrew Cupps
 -->
 <script lang="ts">
-    import { onMount } from "svelte";
     import InstructorListing from "./InstructorListing.svelte";
     import MeetingListing from "./MeetingListing.svelte";
 
@@ -59,7 +58,9 @@ Copyright (C) 2024 Andrew Cupps
             }
         }
         sectionAdded = !sectionAdded;
-        addHoverSection();
+        if (isDesktop) {
+            addHoverSection();
+        }
     }
 
     function addHoverSection() {

--- a/site/src/components/course-planner/schedule/ClassMeeting.svelte
+++ b/site/src/components/course-planner/schedule/ClassMeeting.svelte
@@ -8,7 +8,9 @@ Copyright (C) 2024 Andrew Cupps
     import { 
         formatClasstime, 
         formatInstructors, 
-        formatLocation 
+        formatLocation, 
+        splitCourseCode
+
     } from '../../../lib/course-planner/Formatting';
     import { getColorFromNumber, timeToNumber } from '../../../lib/course-planner/ClassMeetingUtils';
     import { afterUpdate } from 'svelte';
@@ -78,9 +80,12 @@ Copyright (C) 2024 Andrew Cupps
 
     let elt: HTMLButtonElement;
     let innerHeight: number;
+    let innerWidth: number;
     let h: number;
-    $: if (elt || innerHeight) {
+    let w: number;
+    $: if (elt || innerHeight || innerWidth) {
         afterUpdate(() => {
+            w = elt.offsetWidth;
             h = elt.offsetHeight;  
         });
     }
@@ -126,7 +131,7 @@ Copyright (C) 2024 Andrew Cupps
     
 </script>
 
-<svelte:window bind:innerHeight />
+<svelte:window bind:innerHeight bind:innerWidth />
 
 <button class='absolute w-full justify-center text-black 
                 flex flex-col rounded-lg pb-1 justify-items-center'
@@ -151,67 +156,77 @@ Copyright (C) 2024 Andrew Cupps
         </button>
     {/if}
 
-    <!-- Meeting course codes, instructors, etc. will only show up
-         if the height of the classtime is great enough to fit them -->
-    {#if h > 1.5 * fontSize || isInOther}
-        <div class='w-full text-base font-semibold font-sans rounded-t-lg 
-                            courseCode truncate min-h-[1.5rem]'
-                class:rounded-b-lg={h < 1.75 * fontSize}>
-            {meeting.course}
+    {#if w >= 64}
+        <!-- Meeting course codes, instructors, etc. will only show up
+            if the height of the classtime is great enough to fit them -->
+        {#if h > 1.5 * fontSize || isInOther}
+            <div class='w-full text-base font-semibold font-sans rounded-t-lg
+                                courseCode truncate min-h-[1.5rem]'
+                    class:rounded-b-lg={h < 1.75 * fontSize}>
+                {meeting.course}
+            </div>
+        {/if}
+        <div class='w-full grow font-thin 2xl:font-normal 
+                                                    text-xs font-sans px-2'>
+            {#if h - (24 * fontSize) > (64 * fontSize) || isInOther}
+                <div class='truncate static'  
+                                class:underline={instructorsChange}
+                                class:decoration-dotted={instructorsChange}>
+                    {#if instructorsChange}
+                        <Tooltip text={'⚠ ' + formattedInstructors}
+                        tooltipText='Instructors have changed since 
+                                            you last visited Jupiterp.' />
+                    {:else}
+                        {formattedInstructors}
+                    {/if}
+                </div>
+            {/if}
+            {#if h - (24 * fontSize) > (48 * fontSize) || isInOther}
+                <div class='truncate static'
+                                class:underline={meetingTimeChange 
+                                                        || meetingsTypeChange}
+                                class:decoration-dotted={meetingTimeChange 
+                                                        || meetingsTypeChange}>
+                    {#if meetingTimeChange}
+                        <Tooltip text={'⚠ ' + formattedTime}
+                            tooltipText='Class meeting time has changed since 
+                                                you last visited Jupiterp.' />
+                    {:else if meetingsTypeChange}
+                        <Tooltip text={'⚠ ' + formattedTime}
+                            tooltipText='Meeting type has changed since you
+                                            last visited Jupiterp.' />
+                    {:else}
+                        {formattedTime}
+                    {/if}
+                </div>
+            {/if}
+            {#if h - (24 * fontSize) > (32 * fontSize) || isInOther}
+                <div class='truncate static'>
+                    Section {secCode}
+                </div>
+            {/if}
+            {#if h - (24 * fontSize) > (16 * fontSize) && hasLocation}
+                <div class='truncate static'
+                                class:underline={meetingLocChange}
+                                class:decoration-dotted={meetingLocChange}>
+                    {#if meetingLocChange}
+                        <Tooltip text={'⚠ ' + location} 
+                            tooltipText='Class location has changed since 
+                                                you last visited Jupiterp.' />
+                    {:else}
+                        {location}
+                    {/if}
+                </div>
+            {/if}
         </div>
-    {/if}
-    <div class='w-full grow font-thin 2xl:font-normal text-xs font-sans px-2'>
-        {#if h - (24 * fontSize) > (64 * fontSize) || isInOther}
-            <div class='truncate static'  
-                            class:underline={instructorsChange}
-                            class:decoration-dotted={instructorsChange}>
-                {#if instructorsChange}
-                    <Tooltip text={'⚠ ' + formattedInstructors}
-                    tooltipText='Instructors have changed since 
-                                        you last visited Jupiterp.' />
-                {:else}
-                    {formattedInstructors}
-                {/if}
-            </div>
-        {/if}
-        {#if h - (24 * fontSize) > (48 * fontSize) || isInOther}
-            <div class='truncate static'
-                            class:underline={meetingTimeChange 
-                                                    || meetingsTypeChange}
-                            class:decoration-dotted={meetingTimeChange 
-                                                    || meetingsTypeChange}>
-                {#if meetingTimeChange}
-                    <Tooltip text={'⚠ ' + formattedTime}
-                        tooltipText='Class meeting time has changed since 
-                                            you last visited Jupiterp.' />
-                {:else if meetingsTypeChange}
-                    <Tooltip text={'⚠ ' + formattedTime}
-                        tooltipText='Meeting type has changed since you
-                                        last visited Jupiterp.' />
-                {:else}
-                    {formattedTime}
-                {/if}
-            </div>
-        {/if}
-        {#if h - (24 * fontSize) > (32 * fontSize) || isInOther}
-            <div class='truncate static'>
-                Section {secCode}
-            </div>
-        {/if}
-        {#if h - (24 * fontSize) > (16 * fontSize) && hasLocation}
-            <div class='truncate static'
-                            class:underline={meetingLocChange}
-                            class:decoration-dotted={meetingLocChange}>
-                {#if meetingLocChange}
-                    <Tooltip text={'⚠ ' + location} 
-                        tooltipText='Class location has changed since 
-                                            you last visited Jupiterp.' />
-                {:else}
-                    {location}
-                {/if}
-            </div>
-        {/if}
+    {:else}
+        
+    <div class='w-full text-base font-semibold f
+                    ont-sans rounded-t-lg text-wrap break-words'
+        class:rounded-b-lg={h < 1.75 * fontSize}>
+        {splitCourseCode(meeting.course)}
     </div>
+    {/if}
 </button>
 
 <style>

--- a/site/src/components/course-planner/schedule/ClassMeeting.svelte
+++ b/site/src/components/course-planner/schedule/ClassMeeting.svelte
@@ -28,11 +28,14 @@ Copyright (C) 2024 Andrew Cupps
 
     const differences: string[] = meeting.differences;
     const instructorsChange: boolean = differences.includes('Instructors');
-    const numClassMeetingsChange: boolean = differences.includes('Number of class meetings');
-    const meetingsTypeChange: boolean = differences.includes('Type of meeting');
+    const numClassMeetingsChange: boolean = 
+                            differences.includes('Number of class meetings');
+    const meetingsTypeChange: boolean = 
+                                    differences.includes('Type of meeting');
     const meetingTimeChange: boolean = numClassMeetingsChange ||
-                                differences.includes('Meeting time');
-    const meetingLocChange: boolean = differences.includes('Meeting location');
+                                         differences.includes('Meeting time');
+    const meetingLocChange: boolean = 
+                                    differences.includes('Meeting location');
 
     let formattedInstructors: string = formatInstructors(meeting.instructors);
     let formattedTime: string;
@@ -128,7 +131,7 @@ Copyright (C) 2024 Andrew Cupps
             showSectionInfo = meeting.secCode;
         }
     }
-    
+
 </script>
 
 <svelte:window bind:innerHeight bind:innerWidth />
@@ -143,7 +146,7 @@ Copyright (C) 2024 Andrew Cupps
                 width: {(1 / meeting.conflictTotal) * 100}%;
                 left: {((meeting.conflictIndex - 1) / meeting.conflictTotal) * 100}%;'
         class:otherCategoryClassMeeting={isInOther}>
-    
+
     <!-- x button to remove course -->
     {#if !meeting.hover}
         <button class='absolute h-4 w-4 top-0 right-0
@@ -221,7 +224,7 @@ Copyright (C) 2024 Andrew Cupps
         </div>
     {:else}
         
-    <div class='w-full text-base font-semibold f
+    <div class='w-full text-base font-semibold font-sans
                     ont-sans rounded-t-lg text-wrap break-words'
         class:rounded-b-lg={h < 1.75 * fontSize}>
         {splitCourseCode(meeting.course)}

--- a/site/src/components/course-planner/schedule/Schedule.svelte
+++ b/site/src/components/course-planner/schedule/Schedule.svelte
@@ -12,9 +12,11 @@ Copyright (C) 2024 Andrew Cupps
     import ScheduleBackground from './ScheduleBackground.svelte';
     import { formatCredits, testudoLink } from '../../../lib/course-planner/Formatting';
     import { afterUpdate } from 'svelte';
+    import InstructorListing from '../course-search/InstructorListing.svelte';
 
     export let hoveredSection: ScheduleSelection | null;
     export let selections: ScheduleSelection[] = [];
+    export let profsLookup: Record<string, Professor>;
 
     let schedule: Schedule = schedulify(
         appendHoveredSection(selections, hoveredSection)
@@ -68,15 +70,18 @@ Copyright (C) 2024 Andrew Cupps
     }
 
     let elt: HTMLDivElement;
+    let innerWidth: number;
     let infoPanelLeft: number;
     let infoPanelWidth: number;
-    $: if (elt) {
+    $: if (elt || innerWidth) {
         afterUpdate(() => {
             infoPanelLeft = elt.getBoundingClientRect().left;
             infoPanelWidth = elt.getBoundingClientRect().right - infoPanelLeft;
-        })
+        });
     }
 </script>
+
+<svelte:window bind:innerWidth />
 
 <div class='h-full w-full flex flex-row px-2 font-medium overflow-x-scroll
             text-lg text-center text-black dark:text-white overflow-y-scroll'>
@@ -195,9 +200,12 @@ Copyright (C) 2024 Andrew Cupps
         {formatCredits(courseInfoCourse.credits)} credits |
         Section {courseInfoSection.sec_code}
     </div>
-    <div class='text-sm 2xl:text-base'>
-        {courseInfoSection.instructors.join(', ')}
-    </div>
+    {#each courseInfoSection.instructors as instructor}
+        <InstructorListing instructor={instructor}
+                            profs={profsLookup}
+                            profsHover={false}
+                            removeHoverSection={() => {}} />
+    {/each}
     <div class='text-base 2xl:text-lg leading-5'>
         {courseInfoCourse.description}
     </div>

--- a/site/src/components/course-planner/schedule/Schedule.svelte
+++ b/site/src/components/course-planner/schedule/Schedule.svelte
@@ -85,7 +85,7 @@ Copyright (C) 2024 Andrew Cupps
 
 <div class='h-full w-full flex flex-row px-2 font-medium overflow-x-scroll
             text-lg text-center text-black dark:text-white overflow-y-scroll'>
-    <div class='grid grow relative pl-8 min-w-[768px]'
+    <div class='grid grow relative pl-8'
          style='height: calc(100% - 1.75rem);'
          class:grid-cols-5={schedule.other.length == 0}
          class:grid-cols-6={schedule.other.length > 0}

--- a/site/src/lib/course-planner/Formatting.ts
+++ b/site/src/lib/course-planner/Formatting.ts
@@ -110,3 +110,14 @@ export function formatInstructors(instructors: string[]): string {
 export function testudoLink(courseCode: string): string {
     return 'https://app.testudo.umd.edu/soc/search?courseId=' + courseCode + '&sectionId=&termId=202408&_openSectionsOnly=on&creditCompare=%3E%3D&credits=0.0&courseLevelFilter=ALL&instructor=&_facetoface=on&_blended=on&_online=on&courseStartCompare=&courseStartHour=&courseStartMin=&courseStartAM=&courseEndHour=&courseEndMin=&courseEndAM=&teachingCenter=ALL&_classDay1=on&_classDay2=on&_classDay3=on&_classDay4=on&_classDay5=on'
 }
+
+/**
+ * Splits a `code` into its four letter department code and three numbers
+ * as a single string, space delimited.
+ * Example: `splitCourseCode('CMSC424') --> 'CMSC 424'
+ * @param code A `string` code to split apart
+ * @returns `code` split into 
+ */
+export function splitCourseCode(code: string): string {
+    return code.slice(0, 4) + ' ' + code.slice(4);
+}

--- a/site/src/routes/+page.svelte
+++ b/site/src/routes/+page.svelte
@@ -9,9 +9,13 @@ Copyright (C) 2024 Andrew Cupps
     import CourseSearch from '../components/course-planner/course-search/CourseSearch.svelte';
     import { onMount } from 'svelte';
     import { retrieveCourses } from '../lib/course-planner/CourseLoad';
+    import { getProfsLookup } from '$lib/course-planner/CourseSearch';
 
     // Load data from `+page.ts`
     export let data;
+
+    // Create a professor lookup table
+    const profsLookup = getProfsLookup(data.professors);
 
     // Keep track of chosen sections
     let hoveredSection: ScheduleSelection | null = null;
@@ -73,6 +77,8 @@ Copyright (C) 2024 Andrew Cupps
             text-textLight dark:text-textDark lg:px-8
             top-[3rem] lg:top-[3.5rem] xl:top-[4rem] bottom-0'>
     <CourseSearch bind:selections={selectedSections} data={data}
-                    bind:courseSearchSelected bind:hoveredSection />
-    <Schedule bind:selections={selectedSections} bind:hoveredSection />
+                    bind:courseSearchSelected bind:hoveredSection 
+                    profsLookup={profsLookup} />
+    <Schedule bind:selections={selectedSections} bind:hoveredSection 
+                    profsLookup={profsLookup}/>
 </div>


### PR DESCRIPTION
The course info panel that appears when a user clicks on a class meeting on the `Schedule` shows professor ratings.

Adjustments to mobile UI:
- Schedule now fully scales and fits screen with mobile UI; `ClassMeeting` text changes appropriately
- Hovering section listings feature removed on small screens since this interferes with tap-based UI

Resolves #161; closes #49 by fitting to screen by default since it seems to be much more useful.

@alanliu2009 please review on desktop and on mobile.