### PR TITLE
Change cron job to run at 10:30 after dst time change

### DIFF
--- a/.github/workflows/datagen.yml
+++ b/.github/workflows/datagen.yml
@@ -3,7 +3,7 @@ name: Automatic Datagen
 on:
     workflow_dispatch:
     schedule:
-        - cron: '30 15 * * *'
+        - cron: '30 14 * * *'
 
 jobs:
     test-commit-and-pr:


### PR DESCRIPTION
After daylight saving time change, `datagen` now runs at 11:30 am EST instead of 10:30 am; this PR changes it back to 10:30.