### PR TITLE
Fix iPad mobile UI dark mode bug

### DIFF
--- a/site/src/components/layout/DarkModeToggle.svelte
+++ b/site/src/components/layout/DarkModeToggle.svelte
@@ -15,11 +15,11 @@
 </script>
 
 <button class='w-9 h-5 mx-4 bg-transparent border-solid border rounded-[10px]
-                border-outlineLight dark:border-outlineDark xl:translate-y-[10%]
-                hover:border-black dark:hover:border-white
-                hover:transition-colors'
+                border-outlineLight dark:border-outlineDark static
+                hover:border-black dark:hover:border-white 
+                hover:transition-colors translate-y-[0%] xl:translate-y-[10%]'
         on:click={toggleDarkMode} >
-    <div class='relative rounded-[8px] h-4 w-4 top-[50%] translate-y-[-55%]
+    <div class='absolute rounded-[8px] h-4 w-4 top-[50%] translate-y-[-55%]
                 left-0 dark:translate-x-[1.12rem]
                 bg-bgSecondaryLight dark:bg-hoverDark transform
                 transition-transform duration-300 ease-in-out'>

--- a/site/src/components/layout/DarkModeToggle.svelte
+++ b/site/src/components/layout/DarkModeToggle.svelte
@@ -19,7 +19,7 @@
                 hover:border-black dark:hover:border-white 
                 hover:transition-colors translate-y-[0%] xl:translate-y-[10%]'
         on:click={toggleDarkMode} >
-    <div class='absolute rounded-[8px] h-4 w-4 top-[50%] translate-y-[-55%]
+    <div class='absolute rounded-[8px] h-4 w-4 top-[50%] translate-y-[-50%]
                 left-0 dark:translate-x-[1.12rem]
                 bg-bgSecondaryLight dark:bg-hoverDark transform
                 transition-transform duration-300 ease-in-out'>


### PR DESCRIPTION
Currently, the dark mode toggle on iPad horizontal layout has a UI bug where the sun/moon icon appears vertically above the container box. This PR fixes that by ensuring it remains inside the whole time.