### PR TITLE
Allow overindented comments in Clippy

### DIFF
--- a/datagen/src/lib.rs
+++ b/datagen/src/lib.rs
@@ -9,6 +9,8 @@
 //! as well as by the tests in `tests.rs` to ensure the data generation
 //! functions are working as expected.
 
+#![allow(clippy::doc_overindented_list_items)]
+
 use regex::Regex;
 use reqwest::{
     blocking::{Client, Response},


### PR DESCRIPTION
Newest version of clippy has a weird rule that makes it so you can't overindent comment blocks. This is bad because Jupiterp's codebase often intentionally uses overindented comment blocks for readability within the file. It also doesn't actually affect the markdown rendering of the comments so there's no reason for this lint rule to be enforced. This PR allows overindented blocks.