### PR TITLE
Priyam/bugfix/padding

### DIFF
--- a/site/src/components/course-planner/schedule/Schedule.svelte
+++ b/site/src/components/course-planner/schedule/Schedule.svelte
@@ -140,7 +140,7 @@ Copyright (C) 2026 Andrew Cupps
 	bind:clientHeight={scheduleContainerHeight}
 >
 	<div
-		class="relative grid grow pl-8"
+		class="relative grid grow pl-9"
 		style="height:calc(100% - 1.5rem)"
 		class:grid-cols-5={schedule.other.length == 0}
 		class:grid-cols-6={schedule.other.length > 0}

--- a/site/src/components/course-planner/schedule/Schedule.svelte
+++ b/site/src/components/course-planner/schedule/Schedule.svelte
@@ -140,7 +140,7 @@ Copyright (C) 2026 Andrew Cupps
 	bind:clientHeight={scheduleContainerHeight}
 >
 	<div
-		class="relative grid grow pl-9"
+		class="relative grid grow pl-9 2xl:pl-11"
 		style="height:calc(100% - 1.5rem)"
 		class:grid-cols-5={schedule.other.length == 0}
 		class:grid-cols-6={schedule.other.length > 0}

--- a/site/src/components/course-planner/schedule/TimeLine.svelte
+++ b/site/src/components/course-planner/schedule/TimeLine.svelte
@@ -18,8 +18,8 @@ Copyright (C) 2026 Andrew Cupps
 		{number}
 	</div>
 	<div
-		class="absolute left-8
+		class="absolute left-9
         h-[1px] bg-divBorderLight 2xl:left-10 dark:bg-divBorderDark"
-		style="top: 50%; width: calc(100% - 32px);"
+		style="top: 50%; width: calc(100% - 36px);"
 	/>
 </div>

--- a/site/src/components/course-planner/schedule/TimeLine.svelte
+++ b/site/src/components/course-planner/schedule/TimeLine.svelte
@@ -19,7 +19,7 @@ Copyright (C) 2026 Andrew Cupps
 	</div>
 	<div
 		class="absolute left-9
-        h-[1px] bg-divBorderLight 2xl:left-10 dark:bg-divBorderDark"
-		style="top: 50%; width: calc(100% - 36px);"
+	        h-[1px] w-[calc(100%-36px)] bg-divBorderLight 2xl:left-11 2xl:w-[calc(100%-44px)] dark:bg-divBorderDark"
+		style="top: 50%;"
 	/>
 </div>


### PR DESCRIPTION
Fixed the padding issue between the timeline and Monday schedule blocks, on both standard and wide (`2xl` class) screens. Here is an example of what it looked like before:
<img width="96" height="234" alt="image" src="https://github.com/user-attachments/assets/25aa649a-9ef5-48f7-9994-6b3efe5341b6" />
<img width="98" height="260" alt="image" src="https://github.com/user-attachments/assets/7cf87606-81b8-4b86-a498-7b1ae6995022" />

and now fixed:
<img width="107" height="243" alt="image" src="https://github.com/user-attachments/assets/98f4db8d-adc9-46c1-ac11-3cc390318411" />