### PR TITLE
Add @professor search syntax to course search

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -3102,9 +3102,6 @@
 			"cpu": [
 				"arm"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3117,9 +3114,6 @@
 			"integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
 			"cpu": [
 				"arm"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -3134,9 +3128,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3149,9 +3140,6 @@
 			"integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
 			"cpu": [
 				"arm64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -3166,9 +3154,6 @@
 			"cpu": [
 				"loong64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3181,9 +3166,6 @@
 			"integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
 			"cpu": [
 				"loong64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -3198,9 +3180,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3213,9 +3192,6 @@
 			"integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
 			"cpu": [
 				"ppc64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -3230,9 +3206,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3245,9 +3218,6 @@
 			"integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
 			"cpu": [
 				"riscv64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -3262,9 +3232,6 @@
 			"cpu": [
 				"s390x"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3278,9 +3245,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3293,9 +3257,6 @@
 			"integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -5248,9 +5209,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5265,9 +5223,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5282,9 +5237,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5299,9 +5251,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5316,9 +5265,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5333,9 +5279,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5350,9 +5293,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5367,9 +5307,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [

--- a/site/src/components/course-planner/course-search/CourseFilters.svelte
+++ b/site/src/components/course-planner/course-search/CourseFilters.svelte
@@ -14,15 +14,12 @@ Copyright (C) 2026 Andrew Cupps
 	import { slide } from 'svelte/transition';
 	import type { FilterParams } from '../../../types';
 	import { CourseSearchFilterStore } from '../../../stores/CoursePlannerStores';
-	import { matchingStandardizedProfessorNames } from '$lib/course-planner/CourseSearch';
 
 	let appliedFiltersCount = 0;
 	let showFiltersMenu = false;
 	export let showGenEdMenu = false;
 	let genEdSelections: GenEd[] = [];
 	let onlyOpenSections = false;
-	let instructor: string = '';
-	let matchingInstructors: string[] = [];
 
 	const defaultMinCredits = 0;
 	const defaultMaxCredits = 20;
@@ -54,18 +51,6 @@ Copyright (C) 2026 Andrew Cupps
 			appliedFiltersCount += 1;
 			params.clientSideFilters.onlyOpen = onlyOpenSections;
 		}
-		if (instructor.trim().length > 0) {
-			appliedFiltersCount += 1;
-			matchingInstructors = matchingStandardizedProfessorNames(instructor);
-			if (matchingInstructors.length == 1) {
-				console.log(matchingInstructors[0]);
-				params.serverSideFilters.instructor = matchingInstructors[0];
-			} else {
-				params.serverSideFilters.instructor = undefined;
-			}
-		} else {
-			matchingInstructors = [];
-		}
 
 		if (appliedFiltersCount > 0) {
 			CourseSearchFilterStore.set({
@@ -84,7 +69,6 @@ Copyright (C) 2026 Andrew Cupps
 		minCredits = defaultMinCredits;
 		maxCredits = defaultMaxCredits;
 		onlyOpenSections = false;
-		instructor = '';
 	}
 </script>
 
@@ -258,67 +242,6 @@ Copyright (C) 2026 Andrew Cupps
 					/>
 				</div>
 			</div>
-
-			<!-- Instructor -->
-			<div class="flex flex-row text-xs">
-				<span class="min-w-16"> Instructor: </span>
-				<div class="flex grow flex-col">
-					<!-- Instructor input box -->
-					<div class="flex grow flex-row">
-						<div
-							class="grow rounded-l-md border-b
-                                    border-l border-t
-                                    border-secCodesDark dark:border-divBorderDark"
-						>
-							<input
-								class="w-full rounded-l-md
-                                            border-none bg-bgLight px-2 py-0
-                                            text-xs focus:outline-none
-                                            focus:ring dark:bg-bgDark"
-								type="text"
-								placeholder="Instructor name"
-								bind:value={instructor}
-							/>
-						</div>
-
-						<button
-							class="border-1 h-full self-end
-                                        rounded-r-md border border-secCodesDark
-                                        px-0.5
-                                        hover:bg-hoverLight
-                                        dark:border-divBorderDark
-                                        hover:dark:bg-hoverDark"
-							title="Clear Gen Ed filters"
-							on:click={() => {
-								instructor = '';
-							}}
-						>
-							<CloseOutline class="h-4 w-4" />
-						</button>
-					</div>
-
-					<!-- Matching instructors list -->
-					{#if matchingInstructors.length > 1 || (matchingInstructors.length == 1 && matchingInstructors[0] !== instructor)}
-						<div
-							class="custom-scrollbar z-[60] mt-1 flex max-h-40 w-full flex-col overflow-y-auto rounded-md border border-outlineLight bg-bgLight shadow-lg dark:border-outlineDark dark:bg-bgDark"
-						>
-							{#each matchingInstructors as profName}
-								<button
-									class="cursor-pointer px-2 py-1 text-left hover:bg-outlineLight hover:bg-opacity-20 dark:hover:bg-outlineDark dark:hover:bg-opacity-30"
-									on:click={() => {
-										instructor = profName;
-									}}
-								>
-									{profName}
-								</button>
-							{/each}
-						</div>
-					{/if}
-				</div>
-			</div>
-
-			<!-- Total class size -->
-			<!-- Considering this, add later potentially -->
 
 			<!-- Only open sections -->
 			<div class="flex flex-row items-center text-xs">

--- a/site/src/components/course-planner/course-search/CourseSearch.svelte
+++ b/site/src/components/course-planner/course-search/CourseSearch.svelte
@@ -8,6 +8,7 @@ Copyright (C) 2026 Andrew Cupps
 	import CourseListing from './CourseListing.svelte';
 	import {
 		deptCodeToName,
+		matchingStandardizedProfessorNames,
 		pendingResults,
 		setSearchResults
 	} from '../../../lib/course-planner/CourseSearch';
@@ -108,7 +109,78 @@ Copyright (C) 2026 Andrew Cupps
 		setSearchResults(dept);
 	}
 
+	// Professor suggestions shown when the user types @partial in the search box
+	let profSuggestions: string[] = [];
+	let highlightedProfSuggestionIndex = -1;
+
+	/**
+	 * Returns the partial professor name from an unquoted @word token in
+	 * `input`, or null if no such token is present. Complete @"..." tokens
+	 * are ignored since they are already resolved.
+	 * @param input Raw search input string
+	 */
+	function getProfPartial(input: string): string | null {
+		const withoutQuoted = input.replace(/@"[^"]*"/g, '');
+		const match = /@(\S*)/.exec(withoutQuoted);
+		return match && match[1].length >= 1 ? match[1] : null;
+	}
+
+	$: {
+		const partial = getProfPartial(searchInput);
+		if (partial) {
+			profSuggestions = matchingStandardizedProfessorNames(partial);
+			if (profSuggestions.length === 0) {
+				highlightedProfSuggestionIndex = -1;
+			} else if (highlightedProfSuggestionIndex >= profSuggestions.length) {
+				highlightedProfSuggestionIndex = profSuggestions.length - 1;
+			}
+		} else {
+			profSuggestions = [];
+			highlightedProfSuggestionIndex = -1;
+		}
+	}
+
+	/**
+	 * Selects a professor from the suggestions list, replacing the @partial
+	 * token in the search input with @"Full Name" (multi-word) or @Name
+	 * (single-word), then triggers a new search.
+	 * @param name The standardized professor name to insert
+	 */
+	function selectProfessor(name: string) {
+		const partial = getProfPartial(searchInput);
+		if (partial === null) return;
+
+		const token = `@${partial}`;
+		const replacement = name.includes(' ') ? `@"${name}"` : `@${name}`;
+		searchInput = searchInput.replace(token, replacement);
+		highlightedProfSuggestionIndex = -1;
+		setSearchResults(searchInput);
+	}
+
 	function handleSearchKeydown(event: KeyboardEvent) {
+		// Professor suggestions take priority when visible
+		if (profSuggestions.length > 0) {
+			if (event.key === 'ArrowDown') {
+				event.preventDefault();
+				highlightedProfSuggestionIndex =
+					highlightedProfSuggestionIndex + 1 < profSuggestions.length
+						? highlightedProfSuggestionIndex + 1
+						: 0;
+			} else if (event.key === 'ArrowUp') {
+				event.preventDefault();
+				highlightedProfSuggestionIndex =
+					highlightedProfSuggestionIndex > 0
+						? highlightedProfSuggestionIndex - 1
+						: profSuggestions.length - 1;
+			} else if (event.key === 'Enter') {
+				if (highlightedProfSuggestionIndex >= 0) {
+					event.preventDefault();
+					selectProfessor(profSuggestions[highlightedProfSuggestionIndex]);
+				}
+			}
+			return;
+		}
+
 		if (deptSuggestions.length <= 1 || searchInput.length <= 1) {
 			return;
 		}
@@ -226,7 +298,7 @@ Copyright (C) 2026 Andrew Cupps
 						setSearchResults(searchInput);
 					}}
 					on:keydown={handleSearchKeydown}
-					placeholder="Search course codes, ex: 'MATH140'"
+					placeholder="Search courses (e.g. 'MATH140') or @professor"
 					class="w-full rounded-lg border-2 border-solid border-outlineLight bg-transparent px-2 py-0 text-xl placeholder:text-base lg:text-base lg:placeholder:text-sm dark:border-outlineDark"
 				/>
 			</div>
@@ -247,15 +319,34 @@ Copyright (C) 2026 Andrew Cupps
 		}}
 		on:wheel={handleResultsScroll}
 	>
-		<!-- Department suggestions dropdown -->
-		{#if searchInput.length > 0 && deptSuggestions.length > 1}
+		<!-- Professor suggestions dropdown (shown when @partial is detected) -->
+		{#if profSuggestions.length > 0}
+			<div
+				class="mt-2 rounded-lg border border-outlineLight bg-bgLight shadow-lg dark:border-outlineDark dark:bg-bgDark"
+			>
+				{#each profSuggestions as profName, index}
+					<button
+						type="button"
+						class={`flex w-full items-center px-3 py-1 text-left text-base transition-colors hover:bg-outlineLight hover:bg-opacity-20 lg:text-sm dark:hover:bg-outlineDark dark:hover:bg-opacity-30
+							${highlightedProfSuggestionIndex === index ? `bg-outlineLight bg-opacity-20 dark:bg-outlineDark dark:bg-opacity-30` : ''}`}
+						on:mouseenter={() => {
+							highlightedProfSuggestionIndex = index;
+						}}
+						on:click={() => selectProfessor(profName)}
+					>
+						<span class="grow truncate font-black">@{profName}</span>
+					</button>
+				{/each}
+			</div>
+			<!-- Department suggestions dropdown -->
+		{:else if searchInput.length > 0 && deptSuggestions.length > 1}
 			<div
 				class="mt-2 rounded-lg border border-outlineLight bg-bgLight shadow-lg dark:border-outlineDark dark:bg-bgDark"
 			>
 				{#each deptSuggestions as deptOption, index}
 					<button
 						type="button"
-						class={`flex w-full items-end px-3 py-1 text-left text-base transition-colors hover:bg-outlineLight hover:bg-opacity-20 lg:text-sm dark:hover:bg-outlineDark dark:hover:bg-opacity-30 
+						class={`flex w-full items-end px-3 py-1 text-left text-base transition-colors hover:bg-outlineLight hover:bg-opacity-20 lg:text-sm dark:hover:bg-outlineDark dark:hover:bg-opacity-30
 							${highlightedSuggestionIndex === index ? `bg-outlineLight bg-opacity-20 dark:bg-outlineDark dark:bg-opacity-30` : ''}`}
 						on:mouseenter={() => {
 							highlightedSuggestionIndex = index;

--- a/site/src/lib/course-planner/CourseSearch.ts
+++ b/site/src/lib/course-planner/CourseSearch.ts
@@ -53,6 +53,40 @@ ProfsLookupStore.subscribe((profs) => {
 
 let mostRecentInput: string = '';
 
+/**
+ * Parses a raw search input for an @-prefix professor token, returning the
+ * course-only query and any professor name extracted from `@"Full Name"` or
+ * `@Word` tokens.
+ * @param input Raw search input from the user
+ */
+function parseSearchInput(input: string): {
+	courseQuery: string;
+	professorQuery: string | null;
+	isQuotedProfessor: boolean;
+} {
+	// @"Full Name" — quoted, complete professor name
+	const quotedMatch = /@"([^"]+)"/.exec(input);
+	if (quotedMatch) {
+		return {
+			courseQuery: input.replace(quotedMatch[0], '').trim(),
+			professorQuery: quotedMatch[1],
+			isQuotedProfessor: true
+		};
+	}
+
+	// @Word — unquoted, partial or single-word professor name
+	const unquotedMatch = /@(\S+)/.exec(input);
+	if (unquotedMatch) {
+		return {
+			courseQuery: input.replace(unquotedMatch[0], '').trim(),
+			professorQuery: unquotedMatch[1],
+			isQuotedProfessor: false
+		};
+	}
+
+	return { courseQuery: input, professorQuery: null, isQuotedProfessor: false };
+}
+
 // Filtering data
 let filters: FilterParams = {
 	serverSideFilters: {},
@@ -143,8 +177,30 @@ function filterAndSortCourseArray(courses: Course[]): Course[] {
 export async function setSearchResults(input: string) {
 	mostRecentInput = input;
 
-	// Don't care about case or whitespace in searches
-	const simpleInput: string = input.toUpperCase().replace(/\s/g, '');
+	const { courseQuery, professorQuery, isQuotedProfessor } = parseSearchInput(input);
+
+	// Resolve the effective instructor from the @-prefix token.
+	// A quoted @"Name" is used directly; an unquoted @Word is applied only
+	// when it narrows down to exactly one professor match.
+	let effectiveInstructor: string | undefined = undefined;
+	if (isQuotedProfessor && professorQuery) {
+		effectiveInstructor = professorQuery;
+	} else if (professorQuery) {
+		const matches = matchingStandardizedProfessorNames(professorQuery);
+		if (matches.length === 1) {
+			effectiveInstructor = matches[0];
+		}
+	}
+
+	// Merge the @-prefix instructor with any other active server-side filters
+	// (e.g. GenEd selections from the filters panel).
+	const serverSideFilters = {
+		...filters.serverSideFilters,
+		instructor: effectiveInstructor
+	};
+
+	// Don't care about case or whitespace in course code searches
+	const simpleInput: string = courseQuery.toUpperCase().replace(/\s/g, '');
 
 	// If the search input matches a department code, get the courses for that
 	// department and then filter by course number.
@@ -160,7 +216,7 @@ export async function setSearchResults(input: string) {
 		const requestInput: RequestInput = {
 			type: 'deptCode',
 			value: matchingDepts[0],
-			filters: filters.serverSideFilters
+			filters: serverSideFilters
 		};
 
 		// Get from cache/API
@@ -201,7 +257,7 @@ export async function setSearchResults(input: string) {
 		const requestInput: RequestInput = {
 			type: 'courseNumber',
 			value: numberInput,
-			filters: filters.serverSideFilters
+			filters: serverSideFilters
 		};
 
 		const courses: Course[] = filterAndSortCourseArray(
@@ -223,18 +279,17 @@ export async function setSearchResults(input: string) {
 	}
 
 	// If we reach here, the input is not a valid department code or a course
-	// number. If there is an instructor or GenEd filter applied, we can search
-	// all courses for matches. Only do this if search is empty.
-	const fs = filters.serverSideFilters;
+	// number. If a professor or GenEd filter is active, search all courses.
+	// Only trigger this broad search when the course query portion is empty.
 	if (
 		simpleInput.length === 0 &&
-		((fs.genEds !== undefined && fs.genEds.length > 0) ||
-			(fs.instructor !== undefined && fs.instructor.length > 0))
+		((serverSideFilters.genEds !== undefined && serverSideFilters.genEds.length > 0) ||
+			effectiveInstructor !== undefined)
 	) {
 		const requestInput: RequestInput = {
 			type: 'deptCode',
 			value: '', // Empty prefix to get all courses
-			filters: filters.serverSideFilters
+			filters: serverSideFilters
 		};
 
 		const courses: Course[] = filterAndSortCourseArray(
@@ -251,7 +306,7 @@ export async function setSearchResults(input: string) {
 		return;
 	}
 
-	// If these filters aren't applied, clear results.
+	// No matching search pattern and no active filters — clear results.
 	SearchResultsStore.set([]);
 	return;
 }


### PR DESCRIPTION
 Relates to #918. Typing @ in the search box now triggers professor autocomplete suggestions. Multi-word professor names are automatically quoted on selection. Everything outside of the @ token is treated as a normal course/department search. Unquoted @Word tokens narrow results when they resolve to exactly one professor match; otherwise suggestions stay visible until a name is selected. Removed the separate instructor filter from the filters panel in favor of this inline syntax