### PR TITLE
Chase fournier/schedule generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ rust-project.json
 *.vscode
 
 __pycache__/
+
+/plans

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -137,6 +137,7 @@
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
 			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.29.0",
 				"@babel/generator": "^7.29.0",
@@ -705,6 +706,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -728,6 +730,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2233,6 +2236,7 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
 			"integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
@@ -2254,6 +2258,7 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
 			"integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": ">=14"
 			},
@@ -2290,6 +2295,7 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
 			"integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@opentelemetry/api-logs": "0.57.2",
 				"@types/shimmer": "^1.2.0",
@@ -2820,6 +2826,7 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
 			"integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": ">=14"
 			}
@@ -4388,6 +4395,7 @@
 			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.58.0.tgz",
 			"integrity": "sha512-kT9GCN8yJTkCK1W+Gi/bvGooWAM7y7WXP+yd+rf6QOIjyoK1ERPrMwSufXJUNu2pMWIqruhFvmz+LbOqsEmKmA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@standard-schema/spec": "^1.0.0",
 				"@sveltejs/acorn-typescript": "^1.0.5",
@@ -4429,6 +4437,7 @@
 			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-3.1.2.tgz",
 			"integrity": "sha512-Txsm1tJvtiYeLUVRNqxZGKR/mI+CzuIQuc2gn+YCs9rMTowpNZ2Nqt53JdL8KF9bLhAf2ruR/dr9eZCwdTriRA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@sveltejs/vite-plugin-svelte-inspector": "^2.1.0",
 				"debug": "^4.3.4",
@@ -4898,6 +4907,7 @@
 			"integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.58.0",
 				"@typescript-eslint/types": "8.58.0",
@@ -5547,6 +5557,7 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
 			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -6018,6 +6029,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.10.12",
 				"caniuse-lite": "^1.0.30001782",
@@ -6708,6 +6720,7 @@
 			"deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
@@ -6780,6 +6793,7 @@
 			"integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"eslint-config-prettier": "bin/cli.js"
 			},
@@ -8033,6 +8047,7 @@
 			"integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@jest/core": "30.3.0",
 				"@jest/types": "30.3.0",
@@ -9086,6 +9101,7 @@
 			"resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
 			"integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"jiti": "bin/jiti.js"
 			}
@@ -9115,6 +9131,7 @@
 			"integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"cssstyle": "^4.2.1",
 				"data-urls": "^5.0.0",
@@ -10182,6 +10199,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -10405,6 +10423,7 @@
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
 			"integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -10433,6 +10452,7 @@
 			"resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.5.1.tgz",
 			"integrity": "sha512-65+fr5+cgIKWKiqM1Doum4uX6bY8iFCdztvvp2RcF+AJoieaw9kJOFMNcJo/bkmKYsxFaM9OsVZK/gWauG/5mg==",
 			"license": "MIT",
+			"peer": true,
 			"peerDependencies": {
 				"prettier": "^3.0.0",
 				"svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
@@ -10846,6 +10866,7 @@
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
 			"integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/estree": "1.0.8"
 			},
@@ -11457,6 +11478,7 @@
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.20.tgz",
 			"integrity": "sha512-eeEgGc2DtiUil5ANdtd8vPwt9AgaMdnuUFnPft9F5oMvU/FHu5IHFic+p1dR/UOB7XU2mX2yHW+NcTch4DCh5Q==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.1",
 				"@jridgewell/sourcemap-codec": "^1.4.15",
@@ -11769,6 +11791,7 @@
 			"resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.1.tgz",
 			"integrity": "sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==",
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/dcastil"
@@ -11779,6 +11802,7 @@
 			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
 			"integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@alloc/quick-lru": "^5.2.0",
 				"arg": "^5.0.2",
@@ -12237,6 +12261,7 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"devOptional": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -12378,6 +12403,7 @@
 			"resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
 			"integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.21.3",
 				"postcss": "^8.4.43",

--- a/site/src/components/course-planner/course-search/CourseSearch.svelte
+++ b/site/src/components/course-planner/course-search/CourseSearch.svelte
@@ -6,23 +6,17 @@ Copyright (C) 2026 Andrew Cupps
 -->
 <script lang="ts">
 	import CourseListing from './CourseListing.svelte';
-	import {
-		deptCodeToName,
-		matchingStandardizedProfessorNames,
-		pendingResults,
-		setSearchResults
-	} from '../../../lib/course-planner/CourseSearch';
+	import { pendingResults } from '../../../lib/course-planner/CourseSearch';
 	import { appendHoveredSection } from '../../../lib/course-planner/Schedule';
 	import {
 		HoveredSectionStore,
 		CurrentScheduleStore,
-		SearchResultsStore,
-		DeptSuggestionsStore
+		SearchResultsStore
 	} from '../../../stores/CoursePlannerStores';
 	import ScheduleSelector from './ScheduleSelector.svelte';
 	import type { Course } from '@jupiterp/jupiterp';
 	import type { ScheduleBlock, ScheduleSelection } from '../../../types';
-	import CourseFilters from './CourseFilters.svelte';
+	import CourseSearchBox from './CourseSearchBox.svelte';
 	import SolarSystemLoader from './SolarSystemLoader.svelte';
 	import { createCourseSearchActivationController } from '../../../lib/course-planner/CourseSearchActivation';
 	import { chainScroll } from '../../../lib/course-planner/ChainScroll';
@@ -56,16 +50,6 @@ Copyright (C) 2026 Andrew Cupps
 	let searchResults: Course[] = [];
 	SearchResultsStore.subscribe((results) => {
 		searchResults = results;
-	});
-	let deptSuggestions: string[] = [];
-	let highlightedSuggestionIndex = -1;
-	DeptSuggestionsStore.subscribe((suggestions) => {
-		deptSuggestions = suggestions;
-		if (suggestions.length === 0) {
-			highlightedSuggestionIndex = -1;
-		} else if (highlightedSuggestionIndex >= suggestions.length) {
-			highlightedSuggestionIndex = suggestions.length - 1;
-		}
 	});
 
 	let isPendingResults = false;
@@ -102,112 +86,6 @@ Copyright (C) 2026 Andrew Cupps
 		keyboardPrimeElement: () => keyboardPrimeElement,
 		scrollToSearch
 	});
-
-	function selectDepartment(dept: string) {
-		searchInput = dept;
-		highlightedSuggestionIndex = -1;
-		setSearchResults(dept);
-	}
-
-	// Professor suggestions shown when the user types @partial in the search box
-	let profSuggestions: string[] = [];
-	let highlightedProfSuggestionIndex = -1;
-
-	/**
-	 * Returns the partial professor name from an unquoted @word token in
-	 * `input`, or null if no such token is present. Complete @"..." tokens
-	 * are ignored since they are already resolved.
-	 * @param input Raw search input string
-	 */
-	function getProfPartial(input: string): string | null {
-		const withoutQuoted = input.replace(/@"[^"]*"/g, '');
-		const match = /@(\S*)/.exec(withoutQuoted);
-		return match && match[1].length >= 1 ? match[1] : null;
-	}
-
-	$: {
-		const partial = getProfPartial(searchInput);
-		if (partial) {
-			profSuggestions = matchingStandardizedProfessorNames(partial);
-			if (profSuggestions.length === 0) {
-				highlightedProfSuggestionIndex = -1;
-			} else if (highlightedProfSuggestionIndex >= profSuggestions.length) {
-				highlightedProfSuggestionIndex = profSuggestions.length - 1;
-			}
-		} else {
-			profSuggestions = [];
-			highlightedProfSuggestionIndex = -1;
-		}
-	}
-
-	/**
-	 * Selects a professor from the suggestions list, replacing the @partial
-	 * token in the search input with @"Full Name" (multi-word) or @Name
-	 * (single-word), then triggers a new search.
-	 * @param name The standardized professor name to insert
-	 */
-	function selectProfessor(name: string) {
-		const partial = getProfPartial(searchInput);
-		if (partial === null) return;
-
-		const token = `@${partial}`;
-		const replacement = name.includes(' ') ? `@"${name}"` : `@${name}`;
-		searchInput = searchInput.replace(token, replacement);
-		highlightedProfSuggestionIndex = -1;
-		setSearchResults(searchInput);
-	}
-
-	function handleSearchKeydown(event: KeyboardEvent) {
-		// Professor suggestions take priority when visible
-		if (profSuggestions.length > 0) {
-			if (event.key === 'ArrowDown') {
-				event.preventDefault();
-				highlightedProfSuggestionIndex =
-					highlightedProfSuggestionIndex + 1 < profSuggestions.length
-						? highlightedProfSuggestionIndex + 1
-						: 0;
-			} else if (event.key === 'ArrowUp') {
-				event.preventDefault();
-				highlightedProfSuggestionIndex =
-					highlightedProfSuggestionIndex > 0
-						? highlightedProfSuggestionIndex - 1
-						: profSuggestions.length - 1;
-			} else if (event.key === 'Enter') {
-				if (highlightedProfSuggestionIndex >= 0) {
-					event.preventDefault();
-					selectProfessor(profSuggestions[highlightedProfSuggestionIndex]);
-				}
-			}
-			return;
-		}
-
-		if (deptSuggestions.length <= 1 || searchInput.length <= 1) {
-			return;
-		}
-
-		if (event.key === 'ArrowDown') {
-			event.preventDefault();
-			highlightedSuggestionIndex =
-				highlightedSuggestionIndex + 1 < deptSuggestions.length
-					? highlightedSuggestionIndex + 1
-					: 0;
-		} else if (event.key === 'ArrowUp') {
-			event.preventDefault();
-			highlightedSuggestionIndex =
-				highlightedSuggestionIndex > 0
-					? highlightedSuggestionIndex - 1
-					: deptSuggestions.length - 1;
-		} else if (event.key === 'Enter') {
-			if (highlightedSuggestionIndex >= 0 && highlightedSuggestionIndex < deptSuggestions.length) {
-				event.preventDefault();
-				selectDepartment(deptSuggestions[highlightedSuggestionIndex]);
-			}
-		}
-	}
-
-	$: if (searchInput.length <= 1 || deptSuggestions.length <= 1) {
-		highlightedSuggestionIndex = -1;
-	}
 
 	// export let courseSearchSelected: boolean = false;
 
@@ -276,12 +154,21 @@ Copyright (C) 2026 Andrew Cupps
 		<ScheduleSelector />
 
 		<div
-			class="relative flex w-full flex-col border-b-2 border-t-2 border-solid border-divBorderLight dark:border-divBorderDark"
+			class="relative flex w-full flex-col border-b-2 border-t-2 border-solid border-divBorderLight pt-1 dark:border-divBorderDark"
 		>
-			<!-- Course search box -->
-			<div class="relative pt-1">
+			<!-- Course search box (input, filters, and dept/prof suggestions) -->
+			<CourseSearchBox
+				bind:searchInput
+				bind:genEdMenuOpen
+				bind:inputElement={searchInputElement}
+				inputId="planner-course-search-input"
+				inputClass="w-full rounded-lg border-2 border-solid border-outlineLight bg-transparent px-2 py-0 text-xl placeholder:text-base lg:text-base lg:placeholder:text-sm dark:border-outlineDark"
+				onFocus={searchActivation.handleSearchFocus}
+				onBlur={searchActivation.handleSearchBlur}
+			>
 				<!-- Mobile keyboard prime input: used to make the mobile keyboard appear -->
 				<input
+					slot="before-input"
 					type="text"
 					id="mobile-keyboard-prime"
 					bind:this={keyboardPrimeElement}
@@ -289,23 +176,7 @@ Copyright (C) 2026 Andrew Cupps
 					autocomplete="off"
 					class="pointer-events-none fixed left-0 top-0 h-0 w-0 opacity-0"
 				/>
-				<input
-					type="text"
-					id="planner-course-search-input"
-					bind:this={searchInputElement}
-					bind:value={searchInput}
-					on:focus={searchActivation.handleSearchFocus}
-					on:blur={searchActivation.handleSearchBlur}
-					on:input={() => {
-						setSearchResults(searchInput);
-					}}
-					on:keydown={handleSearchKeydown}
-					placeholder="Search courses (e.g. 'MATH140') or @professor"
-					class="w-full rounded-lg border-2 border-solid border-outlineLight bg-transparent px-2 py-0 text-xl placeholder:text-base lg:text-base lg:placeholder:text-sm dark:border-outlineDark"
-				/>
-			</div>
-
-			<CourseFilters bind:showGenEdMenu={genEdMenuOpen} />
+			</CourseSearchBox>
 		</div>
 	</div>
 	<!-- Course search results & dept suggestions [min-height: 20rem - 7.75rem = 12.25rem]-->
@@ -321,51 +192,6 @@ Copyright (C) 2026 Andrew Cupps
 		}}
 		on:wheel={handleResultsScroll}
 	>
-		<!-- Professor suggestions dropdown (shown when @partial is detected) -->
-		{#if profSuggestions.length > 0}
-			<div
-				class="mt-2 rounded-lg border border-outlineLight bg-bgLight shadow-lg dark:border-outlineDark dark:bg-bgDark"
-			>
-				{#each profSuggestions as profName, index}
-					<button
-						type="button"
-						class={`flex w-full items-center px-3 py-1 text-left text-base transition-colors hover:bg-outlineLight hover:bg-opacity-20 lg:text-sm dark:hover:bg-outlineDark dark:hover:bg-opacity-30
-							${highlightedProfSuggestionIndex === index ? `bg-outlineLight bg-opacity-20 dark:bg-outlineDark dark:bg-opacity-30` : ''}`}
-						on:mouseenter={() => {
-							highlightedProfSuggestionIndex = index;
-						}}
-						on:click={() => selectProfessor(profName)}
-					>
-						<span class="grow truncate font-black">@{profName}</span>
-					</button>
-				{/each}
-			</div>
-			<!-- Department suggestions dropdown -->
-		{:else if searchInput.length > 0 && deptSuggestions.length > 1}
-			<div
-				class="mt-2 rounded-lg border border-outlineLight bg-bgLight shadow-lg dark:border-outlineDark dark:bg-bgDark"
-			>
-				{#each deptSuggestions as deptOption, index}
-					<button
-						type="button"
-						class={`flex w-full items-end px-3 py-1 text-left text-base transition-colors hover:bg-outlineLight hover:bg-opacity-20 lg:text-sm dark:hover:bg-outlineDark dark:hover:bg-opacity-30
-							${highlightedSuggestionIndex === index ? `bg-outlineLight bg-opacity-20 dark:bg-outlineDark dark:bg-opacity-30` : ''}`}
-						on:mouseenter={() => {
-							highlightedSuggestionIndex = index;
-						}}
-						on:click={() => selectDepartment(deptOption)}
-					>
-						<span class="min-w-[17%] shrink-0 font-black">
-							{deptOption}
-						</span>
-						<span class="inline-block grow truncate text-xs italic">
-							{deptCodeToName[deptOption]}
-						</span>
-					</button>
-				{/each}
-			</div>
-		{/if}
-
 		<!-- Course search results -->
 		{#each searchResults as courseMatch (courseMatch.courseCode)}
 			<CourseListing course={courseMatch} isDesktop={plannerState.isDesktop} />

--- a/site/src/components/course-planner/course-search/CourseSearchBox.svelte
+++ b/site/src/components/course-planner/course-search/CourseSearchBox.svelte
@@ -1,0 +1,208 @@
+<!--
+This file is part of Jupiterp. For terms of use, please see the file
+called LICENSE at the top level of the Jupiterp source tree (online at
+https://github.com/atcupps/Jupiterp/LICENSE).
+Copyright (C) 2026 Andrew Cupps
+-->
+<!--
+	Shared course-search box: the search input, filters, and professor/department
+	suggestion dropdowns used by both the main planner (CourseSearch.svelte) and
+	the schedule generator (GeneratorCourseSearch.svelte). The owning component
+	supplies the results rendering via the default slot.
+-->
+<script lang="ts">
+	import {
+		deptCodeToName,
+		matchingStandardizedProfessorNames,
+		pendingResults,
+		setSearchResults
+	} from '../../../lib/course-planner/CourseSearch';
+	import {
+		applyProfessorSelection,
+		getProfPartial
+	} from '../../../lib/course-planner/CourseSuggestions';
+	import { DeptSuggestionsStore, SearchResultsStore } from '../../../stores/CoursePlannerStores';
+	import type { Course } from '@jupiterp/jupiterp';
+	import CourseFilters from './CourseFilters.svelte';
+
+	/** Current search text. Two-way bound so the parent can read/clear it. */
+	export let searchInput = '';
+	/** Whether the gen-ed filter menu is open; forwarded to CourseFilters. */
+	export let genEdMenuOpen = false;
+	/** Optional id for the input element (the planner relies on this). */
+	export let inputId: string | undefined = undefined;
+	/** Styling for the input element; defaults to the generator's sizing. */
+	export let inputClass =
+		'w-full rounded-lg border-2 border-solid border-outlineLight bg-transparent px-2 py-1 ' +
+		'text-base placeholder:text-sm focus:outline-none dark:border-outlineDark';
+	export let placeholder = "Search courses (e.g. 'MATH140') or @professor";
+	/** Bound back to the parent so it can manage focus (mobile activation). */
+	export let inputElement: HTMLInputElement | null = null;
+	/** Focus/blur handlers for the planner's mobile keyboard activation. */
+	export let onFocus: (event: FocusEvent) => void = () => {};
+	export let onBlur: (event: FocusEvent) => void = () => {};
+	/** Styling for the suggestion dropdown container. */
+	export let dropdownClass =
+		'mt-2 rounded-lg border border-outlineLight bg-bgLight shadow-lg ' +
+		'dark:border-outlineDark dark:bg-bgDark';
+
+	let searchResults: Course[] = [];
+	SearchResultsStore.subscribe((results) => {
+		searchResults = results;
+	});
+
+	// Department suggestions shown for ambiguous partial department codes.
+	let deptSuggestions: string[] = [];
+	let highlightedDeptIndex = -1;
+	DeptSuggestionsStore.subscribe((suggestions) => {
+		deptSuggestions = suggestions;
+		if (suggestions.length === 0) {
+			highlightedDeptIndex = -1;
+		} else if (highlightedDeptIndex >= suggestions.length) {
+			highlightedDeptIndex = suggestions.length - 1;
+		}
+	});
+
+	// Professor suggestions shown when the user types @partial in the search.
+	let profSuggestions: string[] = [];
+	let highlightedProfIndex = -1;
+
+	$: {
+		const partial = getProfPartial(searchInput);
+		if (partial) {
+			profSuggestions = matchingStandardizedProfessorNames(partial);
+			if (profSuggestions.length === 0) {
+				highlightedProfIndex = -1;
+			} else if (highlightedProfIndex >= profSuggestions.length) {
+				highlightedProfIndex = profSuggestions.length - 1;
+			}
+		} else {
+			profSuggestions = [];
+			highlightedProfIndex = -1;
+		}
+	}
+
+	$: if (searchInput.length <= 1 || deptSuggestions.length <= 1) {
+		highlightedDeptIndex = -1;
+	}
+
+	// Whether the most recent search is still awaiting results.
+	let isPending = false;
+	$: if (searchInput.length > 0 && searchResults.length === 0) {
+		isPending = pendingResults();
+	} else {
+		isPending = false;
+	}
+
+	/**
+	 * Replaces the @partial token with @"Full Name" (multi-word) or @Name
+	 * (single-word) and triggers a new search.
+	 * @param name The standardized professor name to insert
+	 */
+	function selectProfessor(name: string) {
+		if (getProfPartial(searchInput) === null) return;
+		searchInput = applyProfessorSelection(searchInput, name);
+		highlightedProfIndex = -1;
+		setSearchResults(searchInput);
+	}
+
+	function selectDepartment(dept: string) {
+		searchInput = dept;
+		highlightedDeptIndex = -1;
+		setSearchResults(dept);
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		// Professor suggestions take priority when visible.
+		if (profSuggestions.length > 0) {
+			if (event.key === 'ArrowDown') {
+				event.preventDefault();
+				highlightedProfIndex = (highlightedProfIndex + 1) % profSuggestions.length;
+			} else if (event.key === 'ArrowUp') {
+				event.preventDefault();
+				highlightedProfIndex =
+					highlightedProfIndex > 0 ? highlightedProfIndex - 1 : profSuggestions.length - 1;
+			} else if (event.key === 'Enter' && highlightedProfIndex >= 0) {
+				event.preventDefault();
+				selectProfessor(profSuggestions[highlightedProfIndex]);
+			}
+			return;
+		}
+
+		if (deptSuggestions.length <= 1 || searchInput.length <= 1) {
+			return;
+		}
+		if (event.key === 'ArrowDown') {
+			event.preventDefault();
+			highlightedDeptIndex = (highlightedDeptIndex + 1) % deptSuggestions.length;
+		} else if (event.key === 'ArrowUp') {
+			event.preventDefault();
+			highlightedDeptIndex =
+				highlightedDeptIndex > 0 ? highlightedDeptIndex - 1 : deptSuggestions.length - 1;
+		} else if (event.key === 'Enter' && highlightedDeptIndex >= 0) {
+			event.preventDefault();
+			selectDepartment(deptSuggestions[highlightedDeptIndex]);
+		}
+	}
+</script>
+
+<div class="relative flex w-full flex-col">
+	<slot name="before-input" />
+	<input
+		type="text"
+		id={inputId}
+		bind:this={inputElement}
+		bind:value={searchInput}
+		on:focus={onFocus}
+		on:blur={onBlur}
+		on:input={() => setSearchResults(searchInput)}
+		on:keydown={handleKeydown}
+		{placeholder}
+		class={inputClass}
+	/>
+
+	<CourseFilters bind:showGenEdMenu={genEdMenuOpen} />
+
+	<!-- Professor suggestions (shown when @partial is detected) -->
+	{#if profSuggestions.length > 0}
+		<div class={dropdownClass}>
+			{#each profSuggestions as profName, index}
+				<button
+					type="button"
+					class="flex w-full items-center px-3 py-1 text-left text-sm
+						transition-colors hover:bg-outlineLight hover:bg-opacity-20
+						dark:hover:bg-outlineDark dark:hover:bg-opacity-30"
+					class:bg-outlineLight={highlightedProfIndex === index}
+					class:bg-opacity-20={highlightedProfIndex === index}
+					on:mouseenter={() => (highlightedProfIndex = index)}
+					on:click={() => selectProfessor(profName)}
+				>
+					<span class="grow truncate font-black">@{profName}</span>
+				</button>
+			{/each}
+		</div>
+		<!-- Department suggestions -->
+	{:else if searchInput.length > 0 && deptSuggestions.length > 1}
+		<div class={dropdownClass}>
+			{#each deptSuggestions as deptOption, index}
+				<button
+					type="button"
+					class="flex w-full items-end px-3 py-1 text-left text-sm
+						transition-colors hover:bg-outlineLight hover:bg-opacity-20
+						dark:hover:bg-outlineDark dark:hover:bg-opacity-30"
+					class:bg-outlineLight={highlightedDeptIndex === index}
+					class:bg-opacity-20={highlightedDeptIndex === index}
+					on:mouseenter={() => (highlightedDeptIndex = index)}
+					on:click={() => selectDepartment(deptOption)}
+				>
+					<span class="min-w-[17%] shrink-0 font-black">{deptOption}</span>
+					<span class="inline-block grow truncate text-xs italic">
+						{deptCodeToName[deptOption]}
+					</span>
+				</button>
+			{/each}
+		</div>
+	{/if}
+
+	<slot {searchResults} {isPending} {profSuggestions} />
+</div>

--- a/site/src/components/layout/SiteLinks.svelte
+++ b/site/src/components/layout/SiteLinks.svelte
@@ -19,6 +19,11 @@ Copyright (C) 2026 Andrew Cupps
 <!-- For larger screens -->
 <div class="hidden grow justify-end self-center lg:flex">
 	<NavBarElement link="./" text="Course Planner" isOnPage={currentPage == '/'} />
+	<NavBarElement
+		link="./generate"
+		text="Schedule Generator"
+		isOnPage={currentPage == '/generate'}
+	/>
 	<NavBarElement link="./bugs" text="Report an Issue" isOnPage={currentPage == '/bugs'} />
 	<ExpandableNavBarElement link="./about" text="About" isOnPage={currentPage == '/about'}>
 		<NavBarElement
@@ -99,6 +104,9 @@ Copyright (C) 2026 Andrew Cupps
 >
 	<div class="my-2 w-full text-lg">
 		<NavBarElement link="./" text="Course Planner" />
+	</div>
+	<div class="my-2 w-full text-lg">
+		<NavBarElement link="./generate" text="Schedule Generator" />
 	</div>
 	<div class="my-2 w-full text-lg">
 		<NavBarElement link="./bugs" text="Report an Issue" />

--- a/site/src/components/layout/SiteLinks.svelte
+++ b/site/src/components/layout/SiteLinks.svelte
@@ -36,7 +36,7 @@ Copyright (C) 2026 Andrew Cupps
 			link="./privacy-policy"
 			text="Privacy Policy"
 			reduceXMargin={true}
-			fullWidth={true}
+			isOnPage={currentPage == '/privacy-policy'}
 		/>
 		<NavBarElement
 			link="./changelog"

--- a/site/src/components/schedule-generator/ConstraintsPanel.svelte
+++ b/site/src/components/schedule-generator/ConstraintsPanel.svelte
@@ -1,0 +1,190 @@
+<!--
+This file is part of Jupiterp. For terms of use, please see the file
+called LICENSE at the top level of the Jupiterp source tree (online at
+https://github.com/atcupps/Jupiterp/LICENSE).
+Copyright (C) 2026 Andrew Cupps
+-->
+<script lang="ts">
+	import { AdjustmentsHorizontalOutline } from 'flowbite-svelte-icons';
+	import { slide } from 'svelte/transition';
+	import { GeneratorConstraintsStore } from '../../stores/GeneratorStores';
+	import type { HardConstraints } from '../../lib/schedule-generator/types';
+	import type { EngineDay } from '../../lib/schedule-generator/types';
+	import {
+		ENGINE_DAYS,
+		minutesToTimeInput,
+		timeInputToMinutes
+	} from '../../lib/schedule-generator/GeneratorFormat';
+
+	let showMenu = false;
+	let constraints: HardConstraints;
+	GeneratorConstraintsStore.subscribe((c) => {
+		constraints = c;
+	});
+
+	$: activeCount = countActive(constraints);
+	function countActive(c: HardConstraints): number {
+		let count = 0;
+		if (c.earliestStartMinutes !== null) count++;
+		if (c.latestEndMinutes !== null) count++;
+		count += c.daysOff.size;
+		if (c.onlyOpenSeats) count++;
+		if (c.minGapMinutes > 0) count++;
+		if (c.minCredits !== null) count++;
+		return count;
+	}
+
+	function patch(next: Partial<HardConstraints>) {
+		GeneratorConstraintsStore.update((c) => ({ ...c, ...next }));
+	}
+
+	function toggleDay(day: EngineDay) {
+		GeneratorConstraintsStore.update((c) => {
+			const daysOff = new Set(c.daysOff);
+			if (daysOff.has(day)) {
+				daysOff.delete(day);
+			} else {
+				daysOff.add(day);
+			}
+			return { ...c, daysOff };
+		});
+	}
+
+	function reset() {
+		GeneratorConstraintsStore.update((c) => ({
+			...c,
+			earliestStartMinutes: null,
+			latestEndMinutes: null,
+			daysOff: new Set<EngineDay>(),
+			minGapMinutes: 0,
+			minCredits: null
+		}));
+	}
+
+	function setNumberOrNull(value: string): number | null {
+		const parsed = parseInt(value, 10);
+		return Number.isNaN(parsed) ? null : parsed;
+	}
+</script>
+
+<div class="flex flex-col">
+	<div class="flex flex-row items-center justify-between gap-1 py-0.5">
+		<button
+			class="flex grow flex-row items-center text-sm
+				hover:text-orange"
+			on:click={() => (showMenu = !showMenu)}
+			title="Show/hide constraints"
+		>
+			<AdjustmentsHorizontalOutline class="mr-1 h-4 w-4" />
+			{activeCount} constraint{activeCount === 1 ? '' : 's'} applied
+		</button>
+		<button
+			class="text-right text-sm hover:text-orange"
+			on:click={reset}
+			title="Clear all constraints"
+		>
+			Clear
+		</button>
+	</div>
+
+	{#if showMenu}
+		<div class="flex flex-col gap-3 px-1 py-2 text-sm" transition:slide>
+			<!-- Time window -->
+			<div class="flex flex-row flex-wrap items-center gap-3">
+				<label class="flex flex-row items-center gap-2">
+					<span class="opacity-70">No class before</span>
+					<input
+						type="time"
+						value={minutesToTimeInput(constraints.earliestStartMinutes)}
+						on:change={(e) =>
+							patch({
+								earliestStartMinutes: timeInputToMinutes(e.currentTarget.value)
+							})}
+						class="rounded-md border border-outlineLight bg-bgLight
+							px-1 py-0.5 dark:border-outlineDark dark:bg-bgDark"
+					/>
+				</label>
+				<label class="flex flex-row items-center gap-2">
+					<span class="opacity-70">No class after</span>
+					<input
+						type="time"
+						value={minutesToTimeInput(constraints.latestEndMinutes)}
+						on:change={(e) =>
+							patch({
+								latestEndMinutes: timeInputToMinutes(e.currentTarget.value)
+							})}
+						class="rounded-md border border-outlineLight bg-bgLight
+							px-1 py-0.5 dark:border-outlineDark dark:bg-bgDark"
+					/>
+				</label>
+			</div>
+
+			<!-- Days off -->
+			<div class="flex flex-row items-center gap-2">
+				<span class="opacity-70">Days off:</span>
+				<div class="flex flex-row gap-1">
+					{#each ENGINE_DAYS as day}
+						<button
+							class="rounded-md border border-outlineLight px-1.5
+								py-0.5 text-xs dark:border-outlineDark"
+							class:bg-orange={constraints.daysOff.has(day)}
+							class:text-white={constraints.daysOff.has(day)}
+							on:click={() => toggleDay(day)}
+							title={`Toggle ${day} as a day off`}
+						>
+							{day}
+						</button>
+					{/each}
+				</div>
+			</div>
+
+			<!-- Only open seats -->
+			<label class="flex flex-row items-center gap-2">
+				<input
+					type="checkbox"
+					checked={constraints.onlyOpenSeats}
+					on:change={(e) => patch({ onlyOpenSeats: e.currentTarget.checked })}
+					class="rounded-md border-outlineLight text-orange
+						focus:ring-orange dark:border-outlineDark"
+				/>
+				<span class="opacity-80">Only open sections</span>
+			</label>
+
+			<!-- Min gap & min credits -->
+			<div class="flex flex-row flex-wrap items-center gap-4">
+				<label class="flex flex-row items-center gap-2">
+					<span class="opacity-70">Min gap (min)</span>
+					<input
+						type="number"
+						min="0"
+						step="5"
+						value={constraints.minGapMinutes}
+						on:change={(e) =>
+							patch({
+								minGapMinutes: setNumberOrNull(e.currentTarget.value) ?? 0
+							})}
+						class="w-16 rounded-md border border-outlineLight
+							bg-bgLight px-1 py-0.5 dark:border-outlineDark
+							dark:bg-bgDark"
+					/>
+				</label>
+				<label class="flex flex-row items-center gap-2">
+					<span class="opacity-70">Min credits</span>
+					<input
+						type="number"
+						min="0"
+						step="1"
+						value={constraints.minCredits ?? ''}
+						on:change={(e) =>
+							patch({
+								minCredits: setNumberOrNull(e.currentTarget.value)
+							})}
+						class="w-16 rounded-md border border-outlineLight
+							bg-bgLight px-1 py-0.5 dark:border-outlineDark
+							dark:bg-bgDark"
+					/>
+				</label>
+			</div>
+		</div>
+	{/if}
+</div>

--- a/site/src/components/schedule-generator/ConstraintsPanel.svelte
+++ b/site/src/components/schedule-generator/ConstraintsPanel.svelte
@@ -7,14 +7,22 @@ Copyright (C) 2026 Andrew Cupps
 <script lang="ts">
 	import { AdjustmentsHorizontalOutline } from 'flowbite-svelte-icons';
 	import { slide } from 'svelte/transition';
+	import GeneratorSelect from './GeneratorSelect.svelte';
 	import { GeneratorConstraintsStore } from '../../stores/GeneratorStores';
 	import type { HardConstraints } from '../../lib/schedule-generator/types';
 	import type { EngineDay } from '../../lib/schedule-generator/types';
-	import {
-		ENGINE_DAYS,
-		minutesToTimeInput,
-		timeInputToMinutes
-	} from '../../lib/schedule-generator/GeneratorFormat';
+	import { ENGINE_DAYS, timeSlotOptions } from '../../lib/schedule-generator/GeneratorFormat';
+
+	const ANY_TIME = { value: '', label: 'Any time' };
+	const timeOptions = [ANY_TIME, ...timeSlotOptions()];
+
+	function minutesToValue(minutes: number | null): string {
+		return minutes === null ? '' : String(minutes);
+	}
+
+	function valueToMinutes(value: string): number | null {
+		return value === '' ? null : parseInt(value, 10);
+	}
 
 	let showMenu = false;
 	let constraints: HardConstraints;
@@ -91,32 +99,26 @@ Copyright (C) 2026 Andrew Cupps
 		<div class="flex flex-col gap-3 px-1 py-2 text-sm" transition:slide>
 			<!-- Time window -->
 			<div class="flex flex-row flex-wrap items-center gap-3">
-				<label class="flex flex-row items-center gap-2">
+				<div class="flex flex-row items-center gap-2">
 					<span class="opacity-70">No class before</span>
-					<input
-						type="time"
-						value={minutesToTimeInput(constraints.earliestStartMinutes)}
-						on:change={(e) =>
-							patch({
-								earliestStartMinutes: timeInputToMinutes(e.currentTarget.value)
-							})}
-						class="rounded-md border border-outlineLight bg-bgLight
-							px-1 py-0.5 dark:border-outlineDark dark:bg-bgDark"
+					<GeneratorSelect
+						options={timeOptions}
+						value={minutesToValue(constraints.earliestStartMinutes)}
+						onChange={(v) => patch({ earliestStartMinutes: valueToMinutes(v) })}
+						buttonClass="w-28"
+						title="Earliest class start"
 					/>
-				</label>
-				<label class="flex flex-row items-center gap-2">
+				</div>
+				<div class="flex flex-row items-center gap-2">
 					<span class="opacity-70">No class after</span>
-					<input
-						type="time"
-						value={minutesToTimeInput(constraints.latestEndMinutes)}
-						on:change={(e) =>
-							patch({
-								latestEndMinutes: timeInputToMinutes(e.currentTarget.value)
-							})}
-						class="rounded-md border border-outlineLight bg-bgLight
-							px-1 py-0.5 dark:border-outlineDark dark:bg-bgDark"
+					<GeneratorSelect
+						options={timeOptions}
+						value={minutesToValue(constraints.latestEndMinutes)}
+						onChange={(v) => patch({ latestEndMinutes: valueToMinutes(v) })}
+						buttonClass="w-28"
+						title="Latest class end"
 					/>
-				</label>
+				</div>
 			</div>
 
 			<!-- Days off -->

--- a/site/src/components/schedule-generator/CourseWishlist.svelte
+++ b/site/src/components/schedule-generator/CourseWishlist.svelte
@@ -1,0 +1,34 @@
+<!--
+This file is part of Jupiterp. For terms of use, please see the file
+called LICENSE at the top level of the Jupiterp source tree (online at
+https://github.com/atcupps/Jupiterp/LICENSE).
+Copyright (C) 2026 Andrew Cupps
+-->
+<script lang="ts">
+	import GeneratorCourseSearch from './GeneratorCourseSearch.svelte';
+	import WishlistItem from './WishlistItem.svelte';
+	import { GeneratorRequirementsStore } from '../../stores/GeneratorStores';
+	import type { GeneratorRequirement } from '../../stores/GeneratorStores';
+
+	let requirements: GeneratorRequirement[] = [];
+	GeneratorRequirementsStore.subscribe((reqs) => {
+		requirements = reqs;
+	});
+</script>
+
+<div class="flex flex-col gap-2">
+	<h2 class="text-lg font-bold">Courses</h2>
+	<GeneratorCourseSearch />
+
+	{#if requirements.length === 0}
+		<p class="py-2 text-sm opacity-60">
+			Search for courses above and add the ones you want to schedule.
+		</p>
+	{:else}
+		<div class="flex flex-col gap-2">
+			{#each requirements as requirement, index (requirement.course.courseCode)}
+				<WishlistItem {requirement} {index} />
+			{/each}
+		</div>
+	{/if}
+</div>

--- a/site/src/components/schedule-generator/GeneratedScheduleCard.svelte
+++ b/site/src/components/schedule-generator/GeneratedScheduleCard.svelte
@@ -1,0 +1,73 @@
+<!--
+This file is part of Jupiterp. For terms of use, please see the file
+called LICENSE at the top level of the Jupiterp source tree (online at
+https://github.com/atcupps/Jupiterp/LICENSE).
+Copyright (C) 2026 Andrew Cupps
+-->
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import MiniSchedule from './MiniSchedule.svelte';
+	import { applyGeneratedSchedule } from '../../lib/schedule-generator/ApplySchedule';
+	import { formatCredits } from '../../lib/course-planner/Formatting';
+	import type { GeneratedSchedule } from '../../lib/schedule-generator/types';
+
+	export let schedule: GeneratedSchedule;
+	export let rank: number;
+
+	$: metrics = schedule.metrics;
+
+	function formatGap(minutes: number): string {
+		if (minutes === 0) {
+			return 'none';
+		}
+		const hours = Math.floor(minutes / 60);
+		const mins = minutes % 60;
+		if (hours === 0) {
+			return `${mins}m`;
+		}
+		return mins === 0 ? `${hours}h` : `${hours}h ${mins}m`;
+	}
+
+	function apply() {
+		applyGeneratedSchedule(schedule);
+		goto('/');
+	}
+</script>
+
+<div
+	class="flex flex-col gap-2 rounded-xl border border-divBorderLight
+		bg-bgLight p-3 shadow-sm dark:border-divBorderDark dark:bg-bgDark"
+>
+	<div class="flex flex-row items-center justify-between">
+		<span class="text-sm font-semibold opacity-60">#{rank}</span>
+		<button
+			class="rounded-md bg-orange px-3 py-1 text-sm font-semibold
+				text-white hover:opacity-90"
+			on:click={apply}
+			title="Open this schedule in the planner"
+		>
+			Apply
+		</button>
+	</div>
+
+	<MiniSchedule selections={schedule.selections} />
+
+	<div class="flex flex-row flex-wrap gap-x-4 gap-y-1 text-xs opacity-80">
+		<span>
+			{metrics.sectionCount} class{metrics.sectionCount === 1 ? '' : 'es'}
+		</span>
+		<span>
+			{formatCredits(metrics.minCredits, metrics.maxCredits)} cr
+		</span>
+		<span>{metrics.daysWithClasses} days</span>
+		<span>Gaps: {formatGap(metrics.totalGapMinutes)}</span>
+		<span>
+			{#if metrics.avgInstructorRating !== null}
+				★ {metrics.avgInstructorRating.toFixed(1)}
+				({metrics.ratedSectionCount}/{metrics.sectionCount} rated)
+			{:else}
+				Unrated
+			{/if}
+		</span>
+	</div>
+</div>

--- a/site/src/components/schedule-generator/GeneratedScheduleCard.svelte
+++ b/site/src/components/schedule-generator/GeneratedScheduleCard.svelte
@@ -41,8 +41,8 @@ Copyright (C) 2026 Andrew Cupps
 	<div class="flex flex-row items-center justify-between">
 		<span class="text-sm font-semibold opacity-60">#{rank}</span>
 		<button
-			class="rounded-md bg-orange px-3 py-1 text-sm font-semibold
-				text-white hover:opacity-90"
+			class="rounded-md border border-orange px-3 py-1 text-sm font-semibold
+				text-orange enabled:hover:bg-orange enabled:hover:text-white"
 			on:click={apply}
 			title="Open this schedule in the planner"
 		>

--- a/site/src/components/schedule-generator/GeneratorCourseSearch.svelte
+++ b/site/src/components/schedule-generator/GeneratorCourseSearch.svelte
@@ -10,7 +10,9 @@ Copyright (C) 2026 Andrew Cupps
 	import { SearchResultsStore } from '../../stores/CoursePlannerStores';
 	import { GeneratorRequirementsStore } from '../../stores/GeneratorStores';
 	import { formatCredits, splitCourseCode } from '../../lib/course-planner/Formatting';
+	import CourseFilters from '../course-planner/course-search/CourseFilters.svelte';
 
+	let genEdMenuOpen = false;
 	let searchInput = '';
 	let searchResults: Course[] = [];
 	SearchResultsStore.subscribe((results) => {
@@ -50,6 +52,8 @@ Copyright (C) 2026 Andrew Cupps
 			bg-transparent px-2 py-1 text-base placeholder:text-sm
 			focus:outline-none dark:border-outlineDark"
 	/>
+
+	<CourseFilters bind:showGenEdMenu={genEdMenuOpen} />
 
 	{#if searchInput.length > 0}
 		<div class="custom-scrollbar mt-2 max-h-72 overflow-y-auto">

--- a/site/src/components/schedule-generator/GeneratorCourseSearch.svelte
+++ b/site/src/components/schedule-generator/GeneratorCourseSearch.svelte
@@ -6,14 +6,20 @@ Copyright (C) 2026 Andrew Cupps
 -->
 <script lang="ts">
 	import type { Course } from '@jupiterp/jupiterp';
-	import { pendingResults, setSearchResults } from '../../lib/course-planner/CourseSearch';
-	import { SearchResultsStore } from '../../stores/CoursePlannerStores';
+	import {
+		deptCodeToName,
+		matchingStandardizedProfessorNames,
+		pendingResults,
+		setSearchResults
+	} from '../../lib/course-planner/CourseSearch';
+	import { DeptSuggestionsStore, SearchResultsStore } from '../../stores/CoursePlannerStores';
 	import { GeneratorRequirementsStore } from '../../stores/GeneratorStores';
 	import { formatCredits, splitCourseCode } from '../../lib/course-planner/Formatting';
 	import CourseFilters from '../course-planner/course-search/CourseFilters.svelte';
 
 	let genEdMenuOpen = false;
 	let searchInput = '';
+
 	let searchResults: Course[] = [];
 	SearchResultsStore.subscribe((results) => {
 		searchResults = results;
@@ -23,6 +29,101 @@ Copyright (C) 2026 Andrew Cupps
 	GeneratorRequirementsStore.subscribe((reqs) => {
 		chosenCodes = new Set(reqs.map((r) => r.course.courseCode));
 	});
+
+	// Department suggestions shown for ambiguous partial department codes.
+	let deptSuggestions: string[] = [];
+	let highlightedDeptIndex = -1;
+	DeptSuggestionsStore.subscribe((suggestions) => {
+		deptSuggestions = suggestions;
+		if (suggestions.length === 0) {
+			highlightedDeptIndex = -1;
+		} else if (highlightedDeptIndex >= suggestions.length) {
+			highlightedDeptIndex = suggestions.length - 1;
+		}
+	});
+
+	// Professor suggestions shown when the user types @partial in the search.
+	let profSuggestions: string[] = [];
+	let highlightedProfIndex = -1;
+
+	/**
+	 * Returns the partial professor name from an unquoted @word token in
+	 * `input`, or null if no such token is present. Complete @"..." tokens are
+	 * ignored since they are already resolved.
+	 */
+	function getProfPartial(input: string): string | null {
+		const withoutQuoted = input.replace(/@"[^"]*"/g, '');
+		const match = /@(\S*)/.exec(withoutQuoted);
+		return match && match[1].length >= 1 ? match[1] : null;
+	}
+
+	$: {
+		const partial = getProfPartial(searchInput);
+		if (partial) {
+			profSuggestions = matchingStandardizedProfessorNames(partial);
+			if (profSuggestions.length === 0) {
+				highlightedProfIndex = -1;
+			} else if (highlightedProfIndex >= profSuggestions.length) {
+				highlightedProfIndex = profSuggestions.length - 1;
+			}
+		} else {
+			profSuggestions = [];
+			highlightedProfIndex = -1;
+		}
+	}
+
+	/**
+	 * Replaces the @partial token with @"Full Name" (multi-word) or @Name
+	 * (single-word) and triggers a new search, mirroring the main planner.
+	 */
+	function selectProfessor(name: string) {
+		const partial = getProfPartial(searchInput);
+		if (partial === null) return;
+		const token = `@${partial}`;
+		const replacement = name.includes(' ') ? `@"${name}"` : `@${name}`;
+		searchInput = searchInput.replace(token, replacement);
+		highlightedProfIndex = -1;
+		setSearchResults(searchInput);
+	}
+
+	function selectDepartment(dept: string) {
+		searchInput = dept;
+		highlightedDeptIndex = -1;
+		setSearchResults(dept);
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		// Professor suggestions take priority when visible.
+		if (profSuggestions.length > 0) {
+			if (event.key === 'ArrowDown') {
+				event.preventDefault();
+				highlightedProfIndex = (highlightedProfIndex + 1) % profSuggestions.length;
+			} else if (event.key === 'ArrowUp') {
+				event.preventDefault();
+				highlightedProfIndex =
+					highlightedProfIndex > 0 ? highlightedProfIndex - 1 : profSuggestions.length - 1;
+			} else if (event.key === 'Enter' && highlightedProfIndex >= 0) {
+				event.preventDefault();
+				selectProfessor(profSuggestions[highlightedProfIndex]);
+			}
+			return;
+		}
+
+		if (deptSuggestions.length <= 1 || searchInput.length <= 1) {
+			return;
+		}
+		if (event.key === 'ArrowDown') {
+			event.preventDefault();
+			highlightedDeptIndex = (highlightedDeptIndex + 1) % deptSuggestions.length;
+		} else if (event.key === 'ArrowUp') {
+			event.preventDefault();
+			highlightedDeptIndex =
+				highlightedDeptIndex > 0 ? highlightedDeptIndex - 1 : deptSuggestions.length - 1;
+		} else if (event.key === 'Enter' && highlightedDeptIndex >= 0) {
+			event.preventDefault();
+			selectDepartment(deptSuggestions[highlightedDeptIndex]);
+		}
+	}
 
 	let isPending = false;
 	$: if (searchInput.length > 0 && searchResults.length === 0) {
@@ -47,6 +148,7 @@ Copyright (C) 2026 Andrew Cupps
 		type="text"
 		bind:value={searchInput}
 		on:input={() => setSearchResults(searchInput)}
+		on:keydown={handleKeydown}
 		placeholder="Search courses (e.g. 'MATH140') or @professor"
 		class="w-full rounded-lg border-2 border-solid border-outlineLight
 			bg-transparent px-2 py-1 text-base placeholder:text-sm
@@ -54,6 +156,53 @@ Copyright (C) 2026 Andrew Cupps
 	/>
 
 	<CourseFilters bind:showGenEdMenu={genEdMenuOpen} />
+
+	<!-- Professor suggestions (shown when @partial is detected) -->
+	{#if profSuggestions.length > 0}
+		<div
+			class="mt-2 overflow-hidden rounded-lg border border-outlineLight
+				dark:border-outlineDark"
+		>
+			{#each profSuggestions as profName, index}
+				<button
+					type="button"
+					class="flex w-full items-center px-3 py-1 text-left text-sm
+						transition-colors hover:bg-outlineLight hover:bg-opacity-20
+						dark:hover:bg-outlineDark dark:hover:bg-opacity-30"
+					class:bg-outlineLight={highlightedProfIndex === index}
+					class:bg-opacity-20={highlightedProfIndex === index}
+					on:mouseenter={() => (highlightedProfIndex = index)}
+					on:click={() => selectProfessor(profName)}
+				>
+					<span class="grow truncate font-black">@{profName}</span>
+				</button>
+			{/each}
+		</div>
+		<!-- Department suggestions -->
+	{:else if searchInput.length > 0 && deptSuggestions.length > 1}
+		<div
+			class="mt-2 overflow-hidden rounded-lg border border-outlineLight
+				dark:border-outlineDark"
+		>
+			{#each deptSuggestions as deptOption, index}
+				<button
+					type="button"
+					class="flex w-full items-end px-3 py-1 text-left text-sm
+						transition-colors hover:bg-outlineLight hover:bg-opacity-20
+						dark:hover:bg-outlineDark dark:hover:bg-opacity-30"
+					class:bg-outlineLight={highlightedDeptIndex === index}
+					class:bg-opacity-20={highlightedDeptIndex === index}
+					on:mouseenter={() => (highlightedDeptIndex = index)}
+					on:click={() => selectDepartment(deptOption)}
+				>
+					<span class="min-w-[17%] shrink-0 font-black">{deptOption}</span>
+					<span class="inline-block grow truncate text-xs italic">
+						{deptCodeToName[deptOption]}
+					</span>
+				</button>
+			{/each}
+		</div>
+	{/if}
 
 	{#if searchInput.length > 0}
 		<div class="custom-scrollbar mt-2 max-h-72 overflow-y-auto">
@@ -88,7 +237,7 @@ Copyright (C) 2026 Andrew Cupps
 
 			{#if isPending}
 				<div class="py-4 text-center text-sm opacity-60">Searching…</div>
-			{:else if searchResults.length === 0}
+			{:else if searchResults.length === 0 && profSuggestions.length === 0}
 				<div class="py-4 text-center text-sm opacity-60">No courses found.</div>
 			{/if}
 		</div>

--- a/site/src/components/schedule-generator/GeneratorCourseSearch.svelte
+++ b/site/src/components/schedule-generator/GeneratorCourseSearch.svelte
@@ -6,204 +6,39 @@ Copyright (C) 2026 Andrew Cupps
 -->
 <script lang="ts">
 	import type { Course } from '@jupiterp/jupiterp';
-	import {
-		deptCodeToName,
-		matchingStandardizedProfessorNames,
-		pendingResults,
-		setSearchResults
-	} from '../../lib/course-planner/CourseSearch';
-	import { DeptSuggestionsStore, SearchResultsStore } from '../../stores/CoursePlannerStores';
 	import { GeneratorRequirementsStore } from '../../stores/GeneratorStores';
+	import {
+		addRequirement,
+		chosenCourseCodes,
+		removeRequirement
+	} from '../../lib/schedule-generator/WishlistActions';
 	import { formatCredits, splitCourseCode } from '../../lib/course-planner/Formatting';
-	import CourseFilters from '../course-planner/course-search/CourseFilters.svelte';
+	import CourseSearchBox from '../course-planner/course-search/CourseSearchBox.svelte';
 
-	let genEdMenuOpen = false;
 	let searchInput = '';
-
-	let searchResults: Course[] = [];
-	SearchResultsStore.subscribe((results) => {
-		searchResults = results;
-	});
+	let genEdMenuOpen = false;
 
 	let chosenCodes = new Set<string>();
 	GeneratorRequirementsStore.subscribe((reqs) => {
-		chosenCodes = new Set(reqs.map((r) => r.course.courseCode));
+		chosenCodes = chosenCourseCodes(reqs);
 	});
-
-	// Department suggestions shown for ambiguous partial department codes.
-	let deptSuggestions: string[] = [];
-	let highlightedDeptIndex = -1;
-	DeptSuggestionsStore.subscribe((suggestions) => {
-		deptSuggestions = suggestions;
-		if (suggestions.length === 0) {
-			highlightedDeptIndex = -1;
-		} else if (highlightedDeptIndex >= suggestions.length) {
-			highlightedDeptIndex = suggestions.length - 1;
-		}
-	});
-
-	// Professor suggestions shown when the user types @partial in the search.
-	let profSuggestions: string[] = [];
-	let highlightedProfIndex = -1;
-
-	/**
-	 * Returns the partial professor name from an unquoted @word token in
-	 * `input`, or null if no such token is present. Complete @"..." tokens are
-	 * ignored since they are already resolved.
-	 */
-	function getProfPartial(input: string): string | null {
-		const withoutQuoted = input.replace(/@"[^"]*"/g, '');
-		const match = /@(\S*)/.exec(withoutQuoted);
-		return match && match[1].length >= 1 ? match[1] : null;
-	}
-
-	$: {
-		const partial = getProfPartial(searchInput);
-		if (partial) {
-			profSuggestions = matchingStandardizedProfessorNames(partial);
-			if (profSuggestions.length === 0) {
-				highlightedProfIndex = -1;
-			} else if (highlightedProfIndex >= profSuggestions.length) {
-				highlightedProfIndex = profSuggestions.length - 1;
-			}
-		} else {
-			profSuggestions = [];
-			highlightedProfIndex = -1;
-		}
-	}
-
-	/**
-	 * Replaces the @partial token with @"Full Name" (multi-word) or @Name
-	 * (single-word) and triggers a new search, mirroring the main planner.
-	 */
-	function selectProfessor(name: string) {
-		const partial = getProfPartial(searchInput);
-		if (partial === null) return;
-		const token = `@${partial}`;
-		const replacement = name.includes(' ') ? `@"${name}"` : `@${name}`;
-		searchInput = searchInput.replace(token, replacement);
-		highlightedProfIndex = -1;
-		setSearchResults(searchInput);
-	}
-
-	function selectDepartment(dept: string) {
-		searchInput = dept;
-		highlightedDeptIndex = -1;
-		setSearchResults(dept);
-	}
-
-	function handleKeydown(event: KeyboardEvent) {
-		// Professor suggestions take priority when visible.
-		if (profSuggestions.length > 0) {
-			if (event.key === 'ArrowDown') {
-				event.preventDefault();
-				highlightedProfIndex = (highlightedProfIndex + 1) % profSuggestions.length;
-			} else if (event.key === 'ArrowUp') {
-				event.preventDefault();
-				highlightedProfIndex =
-					highlightedProfIndex > 0 ? highlightedProfIndex - 1 : profSuggestions.length - 1;
-			} else if (event.key === 'Enter' && highlightedProfIndex >= 0) {
-				event.preventDefault();
-				selectProfessor(profSuggestions[highlightedProfIndex]);
-			}
-			return;
-		}
-
-		if (deptSuggestions.length <= 1 || searchInput.length <= 1) {
-			return;
-		}
-		if (event.key === 'ArrowDown') {
-			event.preventDefault();
-			highlightedDeptIndex = (highlightedDeptIndex + 1) % deptSuggestions.length;
-		} else if (event.key === 'ArrowUp') {
-			event.preventDefault();
-			highlightedDeptIndex =
-				highlightedDeptIndex > 0 ? highlightedDeptIndex - 1 : deptSuggestions.length - 1;
-		} else if (event.key === 'Enter' && highlightedDeptIndex >= 0) {
-			event.preventDefault();
-			selectDepartment(deptSuggestions[highlightedDeptIndex]);
-		}
-	}
-
-	let isPending = false;
-	$: if (searchInput.length > 0 && searchResults.length === 0) {
-		isPending = pendingResults();
-	} else {
-		isPending = false;
-	}
 
 	function addCourse(course: Course) {
-		if (chosenCodes.has(course.courseCode)) {
-			return;
-		}
-		GeneratorRequirementsStore.update((reqs) => [
-			...reqs,
-			{ course, required: true, pin: { kind: 'none' } }
-		]);
+		GeneratorRequirementsStore.update((reqs) => addRequirement(reqs, course));
+	}
+
+	function removeCourse(course: Course) {
+		GeneratorRequirementsStore.update((reqs) => removeRequirement(reqs, course.courseCode));
 	}
 </script>
 
-<div class="flex flex-col">
-	<input
-		type="text"
-		bind:value={searchInput}
-		on:input={() => setSearchResults(searchInput)}
-		on:keydown={handleKeydown}
-		placeholder="Search courses (e.g. 'MATH140') or @professor"
-		class="w-full rounded-lg border-2 border-solid border-outlineLight
-			bg-transparent px-2 py-1 text-base placeholder:text-sm
-			focus:outline-none dark:border-outlineDark"
-	/>
-
-	<CourseFilters bind:showGenEdMenu={genEdMenuOpen} />
-
-	<!-- Professor suggestions (shown when @partial is detected) -->
-	{#if profSuggestions.length > 0}
-		<div
-			class="mt-2 overflow-hidden rounded-lg border border-outlineLight
-				dark:border-outlineDark"
-		>
-			{#each profSuggestions as profName, index}
-				<button
-					type="button"
-					class="flex w-full items-center px-3 py-1 text-left text-sm
-						transition-colors hover:bg-outlineLight hover:bg-opacity-20
-						dark:hover:bg-outlineDark dark:hover:bg-opacity-30"
-					class:bg-outlineLight={highlightedProfIndex === index}
-					class:bg-opacity-20={highlightedProfIndex === index}
-					on:mouseenter={() => (highlightedProfIndex = index)}
-					on:click={() => selectProfessor(profName)}
-				>
-					<span class="grow truncate font-black">@{profName}</span>
-				</button>
-			{/each}
-		</div>
-		<!-- Department suggestions -->
-	{:else if searchInput.length > 0 && deptSuggestions.length > 1}
-		<div
-			class="mt-2 overflow-hidden rounded-lg border border-outlineLight
-				dark:border-outlineDark"
-		>
-			{#each deptSuggestions as deptOption, index}
-				<button
-					type="button"
-					class="flex w-full items-end px-3 py-1 text-left text-sm
-						transition-colors hover:bg-outlineLight hover:bg-opacity-20
-						dark:hover:bg-outlineDark dark:hover:bg-opacity-30"
-					class:bg-outlineLight={highlightedDeptIndex === index}
-					class:bg-opacity-20={highlightedDeptIndex === index}
-					on:mouseenter={() => (highlightedDeptIndex = index)}
-					on:click={() => selectDepartment(deptOption)}
-				>
-					<span class="min-w-[17%] shrink-0 font-black">{deptOption}</span>
-					<span class="inline-block grow truncate text-xs italic">
-						{deptCodeToName[deptOption]}
-					</span>
-				</button>
-			{/each}
-		</div>
-	{/if}
-
+<CourseSearchBox
+	bind:searchInput
+	bind:genEdMenuOpen
+	let:searchResults
+	let:isPending
+	let:profSuggestions
+>
 	{#if searchInput.length > 0}
 		<div class="custom-scrollbar mt-2 max-h-72 overflow-y-auto">
 			{#each searchResults as course (course.courseCode)}
@@ -224,13 +59,14 @@ Copyright (C) 2026 Andrew Cupps
 					</span>
 					<button
 						class="shrink-0 rounded-md border border-orange px-2
-							py-0.5 text-xs text-orange enabled:hover:bg-orange
-							enabled:hover:text-white disabled:opacity-40"
-						disabled={chosenCodes.has(course.courseCode)}
-						on:click={() => addCourse(course)}
-						title="Add this course to the generator"
+							py-0.5 text-xs text-orange hover:bg-orange hover:text-white"
+						on:click={() =>
+							chosenCodes.has(course.courseCode) ? removeCourse(course) : addCourse(course)}
+						title={chosenCodes.has(course.courseCode)
+							? 'Remove this course from the generator'
+							: 'Add this course to the generator'}
 					>
-						{chosenCodes.has(course.courseCode) ? 'Added' : 'Add'}
+						{chosenCodes.has(course.courseCode) ? 'Remove' : 'Add'}
 					</button>
 				</div>
 			{/each}
@@ -242,4 +78,4 @@ Copyright (C) 2026 Andrew Cupps
 			{/if}
 		</div>
 	{/if}
-</div>
+</CourseSearchBox>

--- a/site/src/components/schedule-generator/GeneratorCourseSearch.svelte
+++ b/site/src/components/schedule-generator/GeneratorCourseSearch.svelte
@@ -1,0 +1,92 @@
+<!--
+This file is part of Jupiterp. For terms of use, please see the file
+called LICENSE at the top level of the Jupiterp source tree (online at
+https://github.com/atcupps/Jupiterp/LICENSE).
+Copyright (C) 2026 Andrew Cupps
+-->
+<script lang="ts">
+	import type { Course } from '@jupiterp/jupiterp';
+	import { pendingResults, setSearchResults } from '../../lib/course-planner/CourseSearch';
+	import { SearchResultsStore } from '../../stores/CoursePlannerStores';
+	import { GeneratorRequirementsStore } from '../../stores/GeneratorStores';
+	import { formatCredits, splitCourseCode } from '../../lib/course-planner/Formatting';
+
+	let searchInput = '';
+	let searchResults: Course[] = [];
+	SearchResultsStore.subscribe((results) => {
+		searchResults = results;
+	});
+
+	let chosenCodes = new Set<string>();
+	GeneratorRequirementsStore.subscribe((reqs) => {
+		chosenCodes = new Set(reqs.map((r) => r.course.courseCode));
+	});
+
+	let isPending = false;
+	$: if (searchInput.length > 0 && searchResults.length === 0) {
+		isPending = pendingResults();
+	} else {
+		isPending = false;
+	}
+
+	function addCourse(course: Course) {
+		if (chosenCodes.has(course.courseCode)) {
+			return;
+		}
+		GeneratorRequirementsStore.update((reqs) => [
+			...reqs,
+			{ course, required: true, pin: { kind: 'none' } }
+		]);
+	}
+</script>
+
+<div class="flex flex-col">
+	<input
+		type="text"
+		bind:value={searchInput}
+		on:input={() => setSearchResults(searchInput)}
+		placeholder="Search courses (e.g. 'MATH140') or @professor"
+		class="w-full rounded-lg border-2 border-solid border-outlineLight
+			bg-transparent px-2 py-1 text-base placeholder:text-sm
+			focus:outline-none dark:border-outlineDark"
+	/>
+
+	{#if searchInput.length > 0}
+		<div class="custom-scrollbar mt-2 max-h-72 overflow-y-auto">
+			{#each searchResults as course (course.courseCode)}
+				<div
+					class="flex flex-row items-center gap-2 border-b
+						border-divBorderLight px-1 py-1 dark:border-divBorderDark"
+				>
+					<div class="flex grow flex-col overflow-hidden">
+						<span class="truncate text-sm font-bold">
+							{splitCourseCode(course.courseCode)}
+						</span>
+						<span class="truncate text-xs opacity-70">
+							{course.name}
+						</span>
+					</div>
+					<span class="whitespace-nowrap text-xs opacity-60">
+						{formatCredits(course.minCredits, course.maxCredits)} cr
+					</span>
+					<button
+						class="shrink-0 rounded-md border border-orange px-2
+							py-0.5 text-xs text-orange enabled:hover:bg-orange
+							enabled:hover:text-white disabled:opacity-40"
+						disabled={chosenCodes.has(course.courseCode)}
+						on:click={() => addCourse(course)}
+						title="Add this course to the generator"
+					>
+						{chosenCodes.has(course.courseCode) ? 'Added' : 'Add'}
+					</button>
+				</div>
+			{/each}
+
+			{#if isPending}
+				<div class="py-4 text-center text-sm opacity-60">Searching…</div>
+			{:else if searchResults.length === 0}
+				<div class="py-4 text-center text-sm opacity-60">No courses found.</div>
+			{/if}
+		</div>
+	{/if}
+</div>

--- a/site/src/components/schedule-generator/GeneratorCourseSearch.svelte
+++ b/site/src/components/schedule-generator/GeneratorCourseSearch.svelte
@@ -39,7 +39,9 @@ Copyright (C) 2026 Andrew Cupps
 	let:isPending
 	let:profSuggestions
 >
-	{#if searchInput.length > 0}
+	<!-- Show results whenever there is a query OR an active filter has produced
+		results (e.g. selecting a gen-ed with an empty search bar). -->
+	{#if searchInput.length > 0 || searchResults.length > 0}
 		<div class="custom-scrollbar mt-2 max-h-72 overflow-y-auto">
 			{#each searchResults as course (course.courseCode)}
 				<div

--- a/site/src/components/schedule-generator/GeneratorSelect.svelte
+++ b/site/src/components/schedule-generator/GeneratorSelect.svelte
@@ -1,0 +1,54 @@
+<!--
+This file is part of Jupiterp. For terms of use, please see the file
+called LICENSE at the top level of the Jupiterp source tree (online at
+https://github.com/atcupps/Jupiterp/LICENSE).
+Copyright (C) 2026 Andrew Cupps
+-->
+<script lang="ts">
+	import { Dropdown, DropdownItem } from 'flowbite-svelte';
+	import { AngleDownOutline } from 'flowbite-svelte-icons';
+
+	export let options: { value: string; label: string }[] = [];
+	export let value: string;
+	export let onChange: (value: string) => void;
+	export let title = '';
+	// Extra classes for the trigger button (e.g. width control).
+	export let buttonClass = '';
+
+	let open = false;
+	$: selected = options.find((o) => o.value === value);
+
+	function choose(next: string) {
+		open = false;
+		onChange(next);
+	}
+</script>
+
+<button
+	type="button"
+	class="flex items-center justify-between gap-1 rounded-md border
+		border-outlineLight bg-bgLight px-2 py-0.5 text-left
+		hover:border-orange dark:border-outlineDark dark:bg-bgDark {buttonClass}"
+	{title}
+>
+	<span class="truncate">{selected ? selected.label : value}</span>
+	<AngleDownOutline class="h-3 w-3 shrink-0 opacity-70" />
+</button>
+
+<Dropdown
+	bind:open
+	class="z-30 max-h-60 overflow-y-auto rounded-md border border-outlineLight
+		bg-bgLight shadow-lg dark:border-outlineDark dark:bg-divBorderDark"
+>
+	{#each options as option}
+		<DropdownItem
+			class="px-3 py-1 text-left text-sm hover:bg-hoverLight dark:hover:bg-hoverDark {option.value ===
+			value
+				? 'font-semibold text-orange'
+				: ''}"
+			on:click={() => choose(option.value)}
+		>
+			{option.label}
+		</DropdownItem>
+	{/each}
+</Dropdown>

--- a/site/src/components/schedule-generator/GeneratorView.svelte
+++ b/site/src/components/schedule-generator/GeneratorView.svelte
@@ -1,0 +1,33 @@
+<!--
+This file is part of Jupiterp. For terms of use, please see the file
+called LICENSE at the top level of the Jupiterp source tree (online at
+https://github.com/atcupps/Jupiterp/LICENSE).
+Copyright (C) 2026 Andrew Cupps
+-->
+<script lang="ts">
+	import CourseWishlist from './CourseWishlist.svelte';
+	import ConstraintsPanel from './ConstraintsPanel.svelte';
+	import ResultsGallery from './ResultsGallery.svelte';
+</script>
+
+<div
+	class="grid grid-cols-1 gap-4 lg:grid-cols-[22rem_minmax(0,1fr)]
+		lg:gap-6"
+>
+	<!-- Inputs: wishlist + constraints -->
+	<div
+		class="custom-scrollbar flex flex-col gap-4 lg:max-h-[calc(100svh-7rem)]
+			lg:overflow-y-auto lg:pr-2"
+	>
+		<CourseWishlist />
+		<div class="border-t border-divBorderLight pt-2 dark:border-divBorderDark">
+			<h2 class="mb-1 text-lg font-bold">Constraints</h2>
+			<ConstraintsPanel />
+		</div>
+	</div>
+
+	<!-- Results -->
+	<div class="custom-scrollbar lg:max-h-[calc(100svh-7rem)] lg:overflow-y-auto">
+		<ResultsGallery />
+	</div>
+</div>

--- a/site/src/components/schedule-generator/MiniSchedule.svelte
+++ b/site/src/components/schedule-generator/MiniSchedule.svelte
@@ -1,0 +1,109 @@
+<!--
+This file is part of Jupiterp. For terms of use, please see the file
+called LICENSE at the top level of the Jupiterp source tree (online at
+https://github.com/atcupps/Jupiterp/LICENSE).
+Copyright (C) 2026 Andrew Cupps
+-->
+<script lang="ts">
+	import { schedulify } from '../../lib/course-planner/Schedule';
+	import { getColorFromNumber } from '../../lib/course-planner/ClassMeetingUtils';
+	import { splitCourseCode } from '../../lib/course-planner/Formatting';
+	import type { ScheduleSelection } from '../../types';
+
+	export let selections: ScheduleSelection[];
+
+	const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
+
+	$: schedule = schedulify(selections);
+	$: days = [
+		schedule.monday,
+		schedule.tuesday,
+		schedule.wednesday,
+		schedule.thursday,
+		schedule.friday
+	];
+	$: hasOther = schedule.other.length > 0;
+
+	// Time window: fit all timed meetings, with a minimum 8-hour window.
+	$: bounds = computeBounds();
+	function computeBounds(): { start: number; end: number } {
+		let earliest = Number.MAX_SAFE_INTEGER;
+		let latest = Number.MIN_SAFE_INTEGER;
+		for (const day of days) {
+			for (const cm of day) {
+				if (typeof cm.meeting !== 'string') {
+					earliest = Math.min(earliest, cm.meeting.classtime.start);
+					latest = Math.max(latest, cm.meeting.classtime.end);
+				}
+			}
+		}
+		if (earliest === Number.MAX_SAFE_INTEGER) {
+			return { start: 8, end: 16 };
+		}
+		let start = Math.floor(earliest);
+		let end = Math.ceil(latest);
+		const diff = end - start;
+		if (diff < 8) {
+			start -= Math.floor((8 - diff) / 2);
+			end += Math.ceil((8 - diff) / 2);
+		}
+		return { start, end };
+	}
+
+	$: span = bounds.end - bounds.start;
+
+	function decStart(meeting: ScheduleSelection['section']['meetings'][number]) {
+		return typeof meeting === 'string' ? 0 : meeting.classtime.start;
+	}
+	function decEnd(meeting: ScheduleSelection['section']['meetings'][number]) {
+		return typeof meeting === 'string' ? 0 : meeting.classtime.end;
+	}
+</script>
+
+<div class="flex flex-col">
+	<div class="flex h-44 flex-row">
+		{#each days as day, dayIndex}
+			<div class="flex grow basis-0 flex-col">
+				<div class="text-center text-[10px] font-semibold opacity-70">
+					{DAY_LABELS[dayIndex]}
+				</div>
+				<div class="relative grow">
+					{#each day as cm}
+						{#if typeof cm.meeting !== 'string'}
+							<div
+								class="absolute overflow-hidden rounded-sm
+									px-0.5 text-[8px] leading-tight text-black"
+								style="top: {((decStart(cm.meeting) - bounds.start) / span) * 100}%;
+									height: {((decEnd(cm.meeting) - decStart(cm.meeting)) / span) * 100}%;
+									width: {(1 / cm.conflictTotal) * 100}%;
+									left: {((cm.conflictIndex - 1) / cm.conflictTotal) * 100}%;
+									background-color: {getColorFromNumber(cm.colorNumber)};"
+								title={`${cm.courseCode} ${cm.sectionCode}`}
+							>
+								<span class="font-semibold">
+									{splitCourseCode(cm.courseCode)}
+								</span>
+							</div>
+						{/if}
+					{/each}
+				</div>
+			</div>
+		{/each}
+	</div>
+
+	{#if hasOther}
+		<div
+			class="mt-1 flex flex-row flex-wrap gap-1 border-t
+				border-divBorderLight pt-1 dark:border-divBorderDark"
+		>
+			{#each schedule.other as cm}
+				<span
+					class="rounded-sm px-1 text-[9px] text-black"
+					style="background-color: {getColorFromNumber(cm.colorNumber)};"
+				>
+					{splitCourseCode(cm.courseCode)} (async)
+				</span>
+			{/each}
+		</div>
+	{/if}
+</div>

--- a/site/src/components/schedule-generator/MiniSchedule.svelte
+++ b/site/src/components/schedule-generator/MiniSchedule.svelte
@@ -124,7 +124,8 @@ Copyright (C) 2026 Andrew Cupps
 					class="rounded-sm px-1 text-[9px] text-black"
 					style="background-color: {getColorFromNumber(cm.colorNumber)};"
 				>
-					{splitCourseCode(cm.courseCode)} (async)
+					{splitCourseCode(cm.courseCode)}
+					{typeof cm.meeting === 'string' ? '(async)' : `(${cm.meeting.classtime.days})`}
 				</span>
 			{/each}
 		</div>

--- a/site/src/components/schedule-generator/MiniSchedule.svelte
+++ b/site/src/components/schedule-generator/MiniSchedule.svelte
@@ -8,13 +8,33 @@ Copyright (C) 2026 Andrew Cupps
 	import { schedulify } from '../../lib/course-planner/Schedule';
 	import { getColorFromNumber } from '../../lib/course-planner/ClassMeetingUtils';
 	import { splitCourseCode } from '../../lib/course-planner/Formatting';
-	import type { ScheduleSelection } from '../../types';
+	import type { Schedule, ScheduleSelection } from '../../types';
 
 	export let selections: ScheduleSelection[];
 
 	const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
 
-	$: schedule = schedulify(selections);
+	const EMPTY_SCHEDULE: Schedule = {
+		monday: [],
+		tuesday: [],
+		wednesday: [],
+		thursday: [],
+		friday: [],
+		other: []
+	};
+
+	// A single malformed section (e.g. an unexpected day code) must never
+	// take down the whole results gallery, so failures degrade to empty.
+	function safeSchedulify(sel: ScheduleSelection[]): Schedule {
+		try {
+			return schedulify(sel);
+		} catch (e) {
+			console.error('Failed to render generated schedule:', e);
+			return EMPTY_SCHEDULE;
+		}
+	}
+
+	$: schedule = safeSchedulify(selections);
 	$: days = [
 		schedule.monday,
 		schedule.tuesday,
@@ -25,11 +45,14 @@ Copyright (C) 2026 Andrew Cupps
 	$: hasOther = schedule.other.length > 0;
 
 	// Time window: fit all timed meetings, with a minimum 8-hour window.
-	$: bounds = computeBounds();
-	function computeBounds(): { start: number; end: number } {
+	$: bounds = computeBounds(days);
+	function computeBounds(weekdays: Schedule[keyof Schedule][]): {
+		start: number;
+		end: number;
+	} {
 		let earliest = Number.MAX_SAFE_INTEGER;
 		let latest = Number.MIN_SAFE_INTEGER;
-		for (const day of days) {
+		for (const day of weekdays) {
 			for (const cm of day) {
 				if (typeof cm.meeting !== 'string') {
 					earliest = Math.min(earliest, cm.meeting.classtime.start);

--- a/site/src/components/schedule-generator/RelaxationHints.svelte
+++ b/site/src/components/schedule-generator/RelaxationHints.svelte
@@ -1,0 +1,64 @@
+<!--
+This file is part of Jupiterp. For terms of use, please see the file
+called LICENSE at the top level of the Jupiterp source tree (online at
+https://github.com/atcupps/Jupiterp/LICENSE).
+Copyright (C) 2026 Andrew Cupps
+-->
+<script lang="ts">
+	import { GeneratorConstraintsStore } from '../../stores/GeneratorStores';
+	import type { RelaxationHint } from '../../stores/GeneratorStores';
+	import { relaxationLabel } from '../../lib/schedule-generator/GeneratorFormat';
+	import { runGeneration } from '../../lib/schedule-generator/Generate';
+
+	export let hints: RelaxationHint[];
+	export let coursesWithNoValidSections: string[];
+
+	function applyHint(hint: RelaxationHint) {
+		GeneratorConstraintsStore.set(hint.relaxation.constraints);
+		runGeneration();
+	}
+</script>
+
+<div class="flex flex-col gap-3">
+	{#if coursesWithNoValidSections.length > 0}
+		<div
+			class="rounded-lg border border-orange bg-lightOrange bg-opacity-30
+				px-3 py-2 text-sm"
+		>
+			No sections fit for:
+			<span class="font-semibold">
+				{coursesWithNoValidSections.join(', ')}
+			</span>. Try relaxing a constraint or unpinning a section.
+		</div>
+	{/if}
+
+	{#if hints.length > 0}
+		<p class="text-sm opacity-80">
+			No schedules fit all your constraints. Loosening one would help:
+		</p>
+		<div class="flex flex-col gap-2">
+			{#each hints as hint}
+				<button
+					class="flex flex-row items-center justify-between gap-2
+						rounded-lg border border-divBorderLight px-3 py-2
+						text-left text-sm hover:border-orange
+						dark:border-divBorderDark"
+					on:click={() => applyHint(hint)}
+				>
+					<span>{relaxationLabel(hint.relaxation)}</span>
+					<span class="shrink-0 text-xs text-orange">
+						{hint.truncated ? '50+' : hint.scheduleCount} schedule{hint.scheduleCount === 1 &&
+						!hint.truncated
+							? ''
+							: 's'}
+					</span>
+				</button>
+			{/each}
+		</div>
+	{:else if coursesWithNoValidSections.length === 0}
+		<p class="text-sm opacity-80">
+			No schedules fit, and no single change unlocks one. Try removing a course, unpinning a
+			section, or relaxing several constraints.
+		</p>
+	{/if}
+</div>

--- a/site/src/components/schedule-generator/ResultsGallery.svelte
+++ b/site/src/components/schedule-generator/ResultsGallery.svelte
@@ -6,6 +6,7 @@ Copyright (C) 2026 Andrew Cupps
 -->
 <script lang="ts">
 	import GeneratedScheduleCard from './GeneratedScheduleCard.svelte';
+	import GeneratorSelect from './GeneratorSelect.svelte';
 	import RelaxationHints from './RelaxationHints.svelte';
 	import { runGeneration } from '../../lib/schedule-generator/Generate';
 	import { sortedByCriterion } from '../../lib/schedule-generator/ScheduleSorter';
@@ -47,6 +48,15 @@ Copyright (C) 2026 Andrew Cupps
 	$: sortedSchedules =
 		state.kind === 'done' ? sortedByCriterion(state.schedules, sort) : ([] as GeneratedSchedule[]);
 	$: visibleSchedules = sortedSchedules.slice(0, visibleCount);
+
+	const sortOptions = SORT_CRITERIA.map((criterion) => ({
+		value: criterion,
+		label: SORT_CRITERION_LABELS[criterion]
+	}));
+
+	function setSort(value: string) {
+		GeneratorSortStore.set(value as SortCriterion);
+	}
 </script>
 
 <div class="flex flex-col gap-3">
@@ -62,21 +72,16 @@ Copyright (C) 2026 Andrew Cupps
 		</button>
 
 		{#if state.kind === 'done' && state.schedules.length > 0}
-			<label class="flex flex-row items-center gap-2 text-sm">
+			<div class="flex flex-row items-center gap-2 text-sm">
 				<span class="opacity-70">Sort by</span>
-				<select
-					class="rounded-md border border-outlineLight bg-bgLight
-						px-2 py-1 dark:border-outlineDark dark:bg-bgDark"
-					bind:value={sort}
-					on:change={() => GeneratorSortStore.set(sort)}
-				>
-					{#each SORT_CRITERIA as criterion}
-						<option value={criterion}>
-							{SORT_CRITERION_LABELS[criterion]}
-						</option>
-					{/each}
-				</select>
-			</label>
+				<GeneratorSelect
+					options={sortOptions}
+					value={sort}
+					onChange={setSort}
+					buttonClass="min-w-36"
+					title="Sort schedules by"
+				/>
+			</div>
 		{/if}
 	</div>
 

--- a/site/src/components/schedule-generator/ResultsGallery.svelte
+++ b/site/src/components/schedule-generator/ResultsGallery.svelte
@@ -35,8 +35,18 @@ Copyright (C) 2026 Andrew Cupps
 		requirements = r;
 	});
 
+	// Render results in pages so a large result set (up to 200 schedules,
+	// each a small grid) never blocks the main thread on first paint.
+	const PAGE_SIZE = 12;
+	let visibleCount = PAGE_SIZE;
+	// Reset the visible window whenever a new generation completes.
+	$: if (state) {
+		visibleCount = PAGE_SIZE;
+	}
+
 	$: sortedSchedules =
 		state.kind === 'done' ? sortedByCriterion(state.schedules, sort) : ([] as GeneratedSchedule[]);
+	$: visibleSchedules = sortedSchedules.slice(0, visibleCount);
 </script>
 
 <div class="flex flex-col gap-3">
@@ -112,9 +122,20 @@ Copyright (C) 2026 Andrew Cupps
 		{/if}
 
 		<div class="grid grid-cols-1 gap-3 md:grid-cols-2 2xl:grid-cols-3">
-			{#each sortedSchedules as schedule, i}
+			{#each visibleSchedules as schedule, i}
 				<GeneratedScheduleCard {schedule} rank={i + 1} />
 			{/each}
 		</div>
+
+		{#if visibleCount < sortedSchedules.length}
+			<button
+				class="mx-auto mt-1 rounded-lg border border-outlineLight px-4
+					py-1.5 text-sm hover:border-orange hover:text-orange
+					dark:border-outlineDark"
+				on:click={() => (visibleCount += PAGE_SIZE)}
+			>
+				Show more ({sortedSchedules.length - visibleCount} more)
+			</button>
+		{/if}
 	{/if}
 </div>

--- a/site/src/components/schedule-generator/ResultsGallery.svelte
+++ b/site/src/components/schedule-generator/ResultsGallery.svelte
@@ -36,7 +36,7 @@ Copyright (C) 2026 Andrew Cupps
 		requirements = r;
 	});
 
-	// Render results in pages so a large result set (up to 200 schedules,
+	// Render results in pages so a large result set (up to 1000 schedules,
 	// each a small grid) never blocks the main thread on first paint.
 	const PAGE_SIZE = 12;
 	let visibleCount = PAGE_SIZE;

--- a/site/src/components/schedule-generator/ResultsGallery.svelte
+++ b/site/src/components/schedule-generator/ResultsGallery.svelte
@@ -1,0 +1,120 @@
+<!--
+This file is part of Jupiterp. For terms of use, please see the file
+called LICENSE at the top level of the Jupiterp source tree (online at
+https://github.com/atcupps/Jupiterp/LICENSE).
+Copyright (C) 2026 Andrew Cupps
+-->
+<script lang="ts">
+	import GeneratedScheduleCard from './GeneratedScheduleCard.svelte';
+	import RelaxationHints from './RelaxationHints.svelte';
+	import { runGeneration } from '../../lib/schedule-generator/Generate';
+	import { sortedByCriterion } from '../../lib/schedule-generator/ScheduleSorter';
+	import { SORT_CRITERIA, SORT_CRITERION_LABELS } from '../../lib/schedule-generator/types';
+	import type { GeneratedSchedule, SortCriterion } from '../../lib/schedule-generator/types';
+	import { overriddenFilterLabel } from '../../lib/schedule-generator/GeneratorFormat';
+	import {
+		GenerationStateStore,
+		GeneratorRequirementsStore,
+		GeneratorSortStore,
+		type GenerationState,
+		type GeneratorRequirement
+	} from '../../stores/GeneratorStores';
+
+	let state: GenerationState = { kind: 'idle' };
+	GenerationStateStore.subscribe((s) => {
+		state = s;
+	});
+
+	let sort: SortCriterion = 'bestRating';
+	GeneratorSortStore.subscribe((s) => {
+		sort = s;
+	});
+
+	let requirements: GeneratorRequirement[] = [];
+	GeneratorRequirementsStore.subscribe((r) => {
+		requirements = r;
+	});
+
+	$: sortedSchedules =
+		state.kind === 'done' ? sortedByCriterion(state.schedules, sort) : ([] as GeneratedSchedule[]);
+</script>
+
+<div class="flex flex-col gap-3">
+	<!-- Generate bar -->
+	<div class="flex flex-row items-center gap-3">
+		<button
+			class="rounded-lg bg-orange px-4 py-1.5 font-semibold text-white
+				hover:opacity-90 disabled:opacity-40"
+			disabled={requirements.length === 0 || state.kind === 'loading'}
+			on:click={() => runGeneration()}
+		>
+			{state.kind === 'loading' ? 'Generating…' : 'Generate schedules'}
+		</button>
+
+		{#if state.kind === 'done' && state.schedules.length > 0}
+			<label class="flex flex-row items-center gap-2 text-sm">
+				<span class="opacity-70">Sort by</span>
+				<select
+					class="rounded-md border border-outlineLight bg-bgLight
+						px-2 py-1 dark:border-outlineDark dark:bg-bgDark"
+					bind:value={sort}
+					on:change={() => GeneratorSortStore.set(sort)}
+				>
+					{#each SORT_CRITERIA as criterion}
+						<option value={criterion}>
+							{SORT_CRITERION_LABELS[criterion]}
+						</option>
+					{/each}
+				</select>
+			</label>
+		{/if}
+	</div>
+
+	{#if state.kind === 'idle'}
+		<p class="py-8 text-center text-sm opacity-60">
+			Add courses and set any constraints, then generate schedules.
+		</p>
+	{:else if state.kind === 'failed'}
+		<div
+			class="rounded-lg border border-orange bg-lightOrange
+				bg-opacity-30 px-3 py-2 text-sm"
+		>
+			{state.message}
+		</div>
+	{:else if state.kind === 'noSchedules'}
+		<RelaxationHints
+			hints={state.hints}
+			coursesWithNoValidSections={state.coursesWithNoValidSections}
+		/>
+	{:else if state.kind === 'done'}
+		{#if state.truncated}
+			<div class="text-xs italic opacity-60">
+				Showing the first {state.schedules.length} schedules; more exist. Add constraints to narrow them
+				down.
+			</div>
+		{/if}
+
+		{#if state.pinNotices.length > 0}
+			<div
+				class="flex flex-col gap-1 rounded-lg border border-orange
+					bg-lightOrange bg-opacity-20 px-3 py-2 text-xs"
+			>
+				{#each state.pinNotices as notice}
+					<div>
+						<span class="font-semibold">
+							{notice.courseCode} ({notice.sectionCode})
+						</span>
+						was pinned even though it
+						{notice.overriddenFilters.map(overriddenFilterLabel).join(', ')}.
+					</div>
+				{/each}
+			</div>
+		{/if}
+
+		<div class="grid grid-cols-1 gap-3 md:grid-cols-2 2xl:grid-cols-3">
+			{#each sortedSchedules as schedule, i}
+				<GeneratedScheduleCard {schedule} rank={i + 1} />
+			{/each}
+		</div>
+	{/if}
+</div>

--- a/site/src/components/schedule-generator/ResultsGallery.svelte
+++ b/site/src/components/schedule-generator/ResultsGallery.svelte
@@ -63,8 +63,8 @@ Copyright (C) 2026 Andrew Cupps
 	<!-- Generate bar -->
 	<div class="flex flex-row items-center gap-3">
 		<button
-			class="rounded-lg bg-orange px-4 py-1.5 font-semibold text-white
-				hover:opacity-90 disabled:opacity-40"
+			class="rounded-lg border border-orange px-4 py-1.5 font-semibold text-orange
+				enabled:hover:bg-orange enabled:hover:text-white disabled:opacity-40"
 			disabled={requirements.length === 0 || state.kind === 'loading'}
 			on:click={() => runGeneration()}
 		>

--- a/site/src/components/schedule-generator/WishlistItem.svelte
+++ b/site/src/components/schedule-generator/WishlistItem.svelte
@@ -1,0 +1,140 @@
+<!--
+This file is part of Jupiterp. For terms of use, please see the file
+called LICENSE at the top level of the Jupiterp source tree (online at
+https://github.com/atcupps/Jupiterp/LICENSE).
+Copyright (C) 2026 Andrew Cupps
+-->
+<script lang="ts">
+	import { CloseOutline } from 'flowbite-svelte-icons';
+	import { splitCourseCode } from '../../lib/course-planner/Formatting';
+	import { GeneratorRequirementsStore } from '../../stores/GeneratorStores';
+	import type { GeneratorRequirement } from '../../stores/GeneratorStores';
+
+	export let requirement: GeneratorRequirement;
+	export let index: number;
+
+	$: sections = requirement.course.sections ?? [];
+	$: instructors = Array.from(new Set(sections.flatMap((s) => s.instructors))).sort();
+	$: pinMode = requirement.pin.kind;
+
+	function patch(next: Partial<GeneratorRequirement>) {
+		GeneratorRequirementsStore.update((reqs) =>
+			reqs.map((r, i) => (i === index ? { ...r, ...next } : r))
+		);
+	}
+
+	function remove() {
+		GeneratorRequirementsStore.update((reqs) => reqs.filter((_, i) => i !== index));
+	}
+
+	function setPinMode(mode: string) {
+		if (mode === 'bySection') {
+			const first = sections[0]?.sectionCode ?? '';
+			patch({ pin: { kind: 'bySection', sectionCode: first } });
+		} else if (mode === 'byInstructor') {
+			patch({ pin: { kind: 'byInstructor', name: instructors[0] ?? '' } });
+		} else {
+			patch({ pin: { kind: 'none' } });
+		}
+	}
+</script>
+
+<div
+	class="flex flex-col gap-1 rounded-lg border border-divBorderLight
+		bg-bgSecondaryLight px-2 py-1.5 dark:border-divBorderDark
+		dark:bg-bgSecondaryDark"
+>
+	<div class="flex flex-row items-center gap-2">
+		<div class="flex grow flex-col overflow-hidden">
+			<span class="truncate text-sm font-bold">
+				{splitCourseCode(requirement.course.courseCode)}
+			</span>
+			<span class="truncate text-xs opacity-70">
+				{requirement.course.name}
+			</span>
+		</div>
+
+		<!-- Required / Optional toggle -->
+		<div
+			class="flex flex-row overflow-hidden rounded-md border
+				border-outlineLight text-xs dark:border-outlineDark"
+		>
+			<button
+				class="px-2 py-0.5"
+				class:bg-orange={requirement.required}
+				class:text-white={requirement.required}
+				on:click={() => patch({ required: true })}
+				title="This course must be in every schedule"
+			>
+				Required
+			</button>
+			<button
+				class="px-2 py-0.5"
+				class:bg-orange={!requirement.required}
+				class:text-white={!requirement.required}
+				on:click={() => patch({ required: false })}
+				title="Include this course only when it fits"
+			>
+				Optional
+			</button>
+		</div>
+
+		<button
+			class="shrink-0 hover:text-orange"
+			on:click={remove}
+			title="Remove course from the generator"
+		>
+			<CloseOutline class="h-4 w-4" />
+		</button>
+	</div>
+
+	<!-- Pin control -->
+	<div class="flex flex-row items-center gap-2 text-xs">
+		<span class="opacity-70">Pin:</span>
+		<select
+			class="rounded-md border border-outlineLight bg-bgLight px-1
+				py-0.5 dark:border-outlineDark dark:bg-bgDark"
+			value={pinMode}
+			on:change={(e) => setPinMode(e.currentTarget.value)}
+		>
+			<option value="none">Any section</option>
+			<option value="bySection">A section</option>
+			<option value="byInstructor">A professor</option>
+		</select>
+
+		{#if requirement.pin.kind === 'bySection'}
+			<select
+				class="grow rounded-md border border-outlineLight bg-bgLight
+					px-1 py-0.5 dark:border-outlineDark dark:bg-bgDark"
+				value={requirement.pin.sectionCode}
+				on:change={(e) =>
+					patch({
+						pin: {
+							kind: 'bySection',
+							sectionCode: e.currentTarget.value
+						}
+					})}
+			>
+				{#each sections as section}
+					<option value={section.sectionCode}>
+						{section.sectionCode}
+					</option>
+				{/each}
+			</select>
+		{:else if requirement.pin.kind === 'byInstructor'}
+			<select
+				class="grow rounded-md border border-outlineLight bg-bgLight
+					px-1 py-0.5 dark:border-outlineDark dark:bg-bgDark"
+				value={requirement.pin.name}
+				on:change={(e) =>
+					patch({
+						pin: { kind: 'byInstructor', name: e.currentTarget.value }
+					})}
+			>
+				{#each instructors as name}
+					<option value={name}>{name}</option>
+				{/each}
+			</select>
+		{/if}
+	</div>
+</div>

--- a/site/src/components/schedule-generator/WishlistItem.svelte
+++ b/site/src/components/schedule-generator/WishlistItem.svelte
@@ -7,6 +7,7 @@ Copyright (C) 2026 Andrew Cupps
 <script lang="ts">
 	import { CloseOutline } from 'flowbite-svelte-icons';
 	import { splitCourseCode } from '../../lib/course-planner/Formatting';
+	import GeneratorSelect from './GeneratorSelect.svelte';
 	import { GeneratorRequirementsStore } from '../../stores/GeneratorStores';
 	import type { GeneratorRequirement } from '../../stores/GeneratorStores';
 
@@ -16,6 +17,8 @@ Copyright (C) 2026 Andrew Cupps
 	$: sections = requirement.course.sections ?? [];
 	$: instructors = Array.from(new Set(sections.flatMap((s) => s.instructors))).sort();
 	$: pinMode = requirement.pin.kind;
+	$: sectionOptions = sections.map((s) => ({ value: s.sectionCode, label: s.sectionCode }));
+	$: instructorOptions = instructors.map((n) => ({ value: n, label: n }));
 
 	function patch(next: Partial<GeneratorRequirement>) {
 		GeneratorRequirementsStore.update((reqs) =>
@@ -45,7 +48,7 @@ Copyright (C) 2026 Andrew Cupps
 		dark:bg-bgSecondaryDark"
 >
 	<div class="flex flex-row items-center gap-2">
-		<div class="flex grow flex-col overflow-hidden">
+		<div class="flex min-w-0 grow flex-col overflow-hidden">
 			<span class="truncate text-sm font-bold">
 				{splitCourseCode(requirement.course.courseCode)}
 			</span>
@@ -56,7 +59,7 @@ Copyright (C) 2026 Andrew Cupps
 
 		<!-- Required / Optional toggle -->
 		<div
-			class="flex flex-row overflow-hidden rounded-md border
+			class="flex shrink-0 flex-row overflow-hidden rounded-md border
 				border-outlineLight text-xs dark:border-outlineDark"
 		>
 			<button
@@ -125,40 +128,21 @@ Copyright (C) 2026 Andrew Cupps
 		</div>
 
 		{#if requirement.pin.kind === 'bySection'}
-			<select
-				class="grow cursor-pointer rounded-md border border-outlineLight
-					bg-transparent px-2 py-0.5 hover:border-orange
-					focus:outline-none dark:border-outlineDark"
+			<GeneratorSelect
+				options={sectionOptions}
 				value={requirement.pin.sectionCode}
-				on:change={(e) =>
-					patch({
-						pin: {
-							kind: 'bySection',
-							sectionCode: e.currentTarget.value
-						}
-					})}
-			>
-				{#each sections as section}
-					<option value={section.sectionCode}>
-						{section.sectionCode}
-					</option>
-				{/each}
-			</select>
+				onChange={(v) => patch({ pin: { kind: 'bySection', sectionCode: v } })}
+				buttonClass="grow"
+				title="Pinned section"
+			/>
 		{:else if requirement.pin.kind === 'byInstructor'}
-			<select
-				class="grow cursor-pointer rounded-md border border-outlineLight
-					bg-transparent px-2 py-0.5 hover:border-orange
-					focus:outline-none dark:border-outlineDark"
+			<GeneratorSelect
+				options={instructorOptions}
 				value={requirement.pin.name}
-				on:change={(e) =>
-					patch({
-						pin: { kind: 'byInstructor', name: e.currentTarget.value }
-					})}
-			>
-				{#each instructors as name}
-					<option value={name}>{name}</option>
-				{/each}
-			</select>
+				onChange={(v) => patch({ pin: { kind: 'byInstructor', name: v } })}
+				buttonClass="grow"
+				title="Pinned professor"
+			/>
 		{/if}
 	</div>
 </div>

--- a/site/src/components/schedule-generator/WishlistItem.svelte
+++ b/site/src/components/schedule-generator/WishlistItem.svelte
@@ -89,23 +89,46 @@ Copyright (C) 2026 Andrew Cupps
 	</div>
 
 	<!-- Pin control -->
-	<div class="flex flex-row items-center gap-2 text-xs">
-		<span class="opacity-70">Pin:</span>
-		<select
-			class="rounded-md border border-outlineLight bg-bgLight px-1
-				py-0.5 dark:border-outlineDark dark:bg-bgDark"
-			value={pinMode}
-			on:change={(e) => setPinMode(e.currentTarget.value)}
+	<div class="flex flex-row flex-wrap items-center gap-2 text-xs">
+		<span class="opacity-70">Pin to:</span>
+		<div
+			class="flex flex-row overflow-hidden rounded-md border
+				border-outlineLight dark:border-outlineDark"
 		>
-			<option value="none">Any section</option>
-			<option value="bySection">A section</option>
-			<option value="byInstructor">A professor</option>
-		</select>
+			<button
+				class="px-2 py-0.5"
+				class:bg-orange={pinMode === 'none'}
+				class:text-white={pinMode === 'none'}
+				on:click={() => setPinMode('none')}
+				title="Consider every section of this course"
+			>
+				Any
+			</button>
+			<button
+				class="border-l border-outlineLight px-2 py-0.5 dark:border-outlineDark"
+				class:bg-orange={pinMode === 'bySection'}
+				class:text-white={pinMode === 'bySection'}
+				on:click={() => setPinMode('bySection')}
+				title="Lock this course to a specific section"
+			>
+				Section
+			</button>
+			<button
+				class="border-l border-outlineLight px-2 py-0.5 dark:border-outlineDark"
+				class:bg-orange={pinMode === 'byInstructor'}
+				class:text-white={pinMode === 'byInstructor'}
+				on:click={() => setPinMode('byInstructor')}
+				title="Lock this course to a specific professor"
+			>
+				Professor
+			</button>
+		</div>
 
 		{#if requirement.pin.kind === 'bySection'}
 			<select
-				class="grow rounded-md border border-outlineLight bg-bgLight
-					px-1 py-0.5 dark:border-outlineDark dark:bg-bgDark"
+				class="grow cursor-pointer rounded-md border border-outlineLight
+					bg-transparent px-2 py-0.5 hover:border-orange
+					focus:outline-none dark:border-outlineDark"
 				value={requirement.pin.sectionCode}
 				on:change={(e) =>
 					patch({
@@ -123,8 +146,9 @@ Copyright (C) 2026 Andrew Cupps
 			</select>
 		{:else if requirement.pin.kind === 'byInstructor'}
 			<select
-				class="grow rounded-md border border-outlineLight bg-bgLight
-					px-1 py-0.5 dark:border-outlineDark dark:bg-bgDark"
+				class="grow cursor-pointer rounded-md border border-outlineLight
+					bg-transparent px-2 py-0.5 hover:border-orange
+					focus:outline-none dark:border-outlineDark"
 				value={requirement.pin.name}
 				on:change={(e) =>
 					patch({

--- a/site/src/lib/course-planner/CourseSearch.ts
+++ b/site/src/lib/course-planner/CourseSearch.ts
@@ -7,7 +7,13 @@
  * @fileoverview Functions relating to searching for courses in Jupiterp.
  */
 
-import type { Course, Instructor } from '@jupiterp/jupiterp';
+import type {
+	Course,
+	Instructor,
+	InstructorsConfig,
+	InstructorsResponse
+} from '@jupiterp/jupiterp';
+import { client } from '$lib/client';
 import { CourseDataCache, type RequestInput } from './CourseDataCache';
 import {
 	DepartmentsStore,
@@ -381,4 +387,42 @@ export function matchingStandardizedProfessorNames(partial: string): string[] {
 		}
 	}
 	return matches;
+}
+
+/**
+ * Fetch all active instructors from the API (paginated) and populate the
+ * `ProfsLookupStore` with a name -> `Instructor` lookup. Used by both the
+ * course planner and the schedule generator pages so instructor ratings are
+ * available wherever they are needed. Errors are logged and swallowed so a
+ * ratings failure never blocks the rest of the page.
+ */
+export async function loadInstructorLookup(): Promise<void> {
+	try {
+		const limit = 500;
+		let offset = 0;
+		let allInstructors: Instructor[] = [];
+		const config: InstructorsConfig = { limit, offset };
+		let complete = false;
+		while (!complete) {
+			const response: InstructorsResponse = await client.activeInstructors(config);
+			if (response.ok() && response.data != null) {
+				allInstructors = [...allInstructors, ...response.data];
+				if (response.data.length < limit) {
+					complete = true;
+					break;
+				}
+				offset += limit;
+				config.offset = offset;
+			} else {
+				// format-check exempt 3
+				throw new Error(
+					`Failed to fetch instructors: ${response.statusCode} ` +
+						`${response.statusMessage} ${response.errorBody}`
+				);
+			}
+		}
+		ProfsLookupStore.set(getProfsLookup(allInstructors));
+	} catch (error) {
+		console.error('Error fetching professor data:', error);
+	}
 }

--- a/site/src/lib/course-planner/CourseSuggestions.test.ts
+++ b/site/src/lib/course-planner/CourseSuggestions.test.ts
@@ -1,0 +1,65 @@
+/**
+ * This file is part of Jupiterp. For terms of use, please see the file
+ * called LICENSE at the top level of the Jupiterp source tree (online at
+ * https://github.com/atcupps/Jupiterp/LICENSE).
+ * Copyright (C) 2026 Andrew Cupps
+ *
+ * @fileoverview Unit tests for CourseSuggestions.ts
+ */
+
+import { applyProfessorSelection, getProfPartial } from './CourseSuggestions';
+import { describe, expect, test } from '@jest/globals';
+
+describe('getProfPartial', () => {
+	test('returns null when there is no @ token', () => {
+		expect(getProfPartial('MATH140')).toBeNull();
+	});
+
+	test('returns null for a bare @ with no following characters', () => {
+		expect(getProfPartial('@')).toBeNull();
+	});
+
+	test('extracts a single-word partial', () => {
+		expect(getProfPartial('@smith')).toBe('smith');
+	});
+
+	test('extracts a partial that follows a course query', () => {
+		expect(getProfPartial('CMSC131 @joh')).toBe('joh');
+	});
+
+	test('stops the partial at the first whitespace', () => {
+		expect(getProfPartial('@john doe')).toBe('john');
+	});
+
+	test('ignores an already-resolved quoted token', () => {
+		expect(getProfPartial('@"Jane Smith"')).toBeNull();
+	});
+
+	test('ignores a resolved quoted token but still finds a later partial', () => {
+		expect(getProfPartial('@"Jane Smith" @ad')).toBe('ad');
+	});
+});
+
+describe('applyProfessorSelection', () => {
+	test('wraps a multi-word name in quotes', () => {
+		expect(applyProfessorSelection('@jane', 'Jane Smith')).toBe('@"Jane Smith"');
+	});
+
+	test('leaves a single-word name unquoted', () => {
+		expect(applyProfessorSelection('@sm', 'Smith')).toBe('@Smith');
+	});
+
+	test('replaces only the partial token, preserving the course query', () => {
+		expect(applyProfessorSelection('CMSC131 @jo', 'John Doe')).toBe('CMSC131 @"John Doe"');
+	});
+
+	test('returns the input unchanged when there is no partial token', () => {
+		expect(applyProfessorSelection('MATH140', 'Jane Smith')).toBe('MATH140');
+	});
+
+	test('does not disturb an existing resolved token', () => {
+		expect(applyProfessorSelection('@"Jane Smith" @ad', 'Alice Adams')).toBe(
+			'@"Jane Smith" @"Alice Adams"'
+		);
+	});
+});

--- a/site/src/lib/course-planner/CourseSuggestions.ts
+++ b/site/src/lib/course-planner/CourseSuggestions.ts
@@ -1,0 +1,37 @@
+/**
+ * This file is part of Jupiterp. For terms of use, please see the file
+ * called LICENSE at the top level of the Jupiterp source tree (online at
+ * https://github.com/atcupps/Jupiterp/LICENSE).
+ * Copyright (C) 2026 Andrew Cupps
+ *
+ * @fileoverview Pure helpers for the course-search professor suggestions,
+ * shared by the planner and generator search boxes. Kept free of Svelte and
+ * `$lib` imports so the token parsing/rewriting can be unit-tested directly.
+ */
+
+/**
+ * Returns the partial professor name from an unquoted `@word` token in `input`,
+ * or null if no such token is present. Complete `@"..."` tokens are ignored
+ * since they are already resolved.
+ * @param input Raw search input string
+ */
+export function getProfPartial(input: string): string | null {
+	const withoutQuoted = input.replace(/@"[^"]*"/g, '');
+	const match = /@(\S*)/.exec(withoutQuoted);
+	return match && match[1].length >= 1 ? match[1] : null;
+}
+
+/**
+ * Replaces the unquoted `@partial` token in `input` with the standardized
+ * professor `name` — `@"Full Name"` for multi-word names or `@Name` for
+ * single-word names. Returns `input` unchanged when there is no partial token.
+ * @param input Raw search input string
+ * @param name The standardized professor name to insert
+ */
+export function applyProfessorSelection(input: string, name: string): string {
+	const partial = getProfPartial(input);
+	if (partial === null) return input;
+	const token = `@${partial}`;
+	const replacement = name.includes(' ') ? `@"${name}"` : `@${name}`;
+	return input.replace(token, replacement);
+}

--- a/site/src/lib/schedule-generator/ApplySchedule.ts
+++ b/site/src/lib/schedule-generator/ApplySchedule.ts
@@ -1,0 +1,58 @@
+/**
+ * This file is part of Jupiterp. For terms of use, please see the file
+ * called LICENSE at the top level of the Jupiterp source tree (online at
+ * https://github.com/atcupps/Jupiterp/LICENSE).
+ * Copyright (C) 2026 Andrew Cupps
+ *
+ * @fileoverview Applies a generated schedule to the course planner. The
+ * planner reads its state from local storage on mount, so this writes there
+ * directly (in the planner's format), saving the generated schedule as a new
+ * named schedule and preserving the user's existing schedules.
+ */
+
+import { resolveSelections, resolveStoredSchedules } from '../course-planner/CourseLoad';
+import { assignColorNumbers } from '../course-planner/Modernization';
+import { uniqueScheduleName } from '../course-planner/ScheduleSelector';
+import type { GeneratedSchedule } from './types';
+import type { ScheduleBlock, StoredSchedule } from '../../types';
+
+const SELECTIONS_KEY = 'selectedSections';
+const NAME_KEY = 'scheduleName';
+const NONSELECTED_KEY = 'nonselectedSchedules';
+
+/** Read the planner's current schedule from local storage. */
+function readCurrentSchedule(): StoredSchedule {
+	const rawSelections = localStorage.getItem(SELECTIONS_KEY);
+	const selections: ScheduleBlock[] = rawSelections ? resolveSelections(rawSelections) : [];
+	const scheduleName = localStorage.getItem(NAME_KEY) ?? 'Schedule 1';
+	return { scheduleName, selections };
+}
+
+/** Read the planner's non-selected schedules from local storage. */
+function readNonselectedSchedules(): StoredSchedule[] {
+	const raw = localStorage.getItem(NONSELECTED_KEY);
+	return raw ? resolveStoredSchedules(raw) : [];
+}
+
+/**
+ * Save `schedule` into the planner as a new named schedule (e.g. "Generated
+ * 1"), demoting the user's existing active schedule to a saved one if it had
+ * any selections. Returns the name assigned to the new schedule.
+ */
+export function applyGeneratedSchedule(schedule: GeneratedSchedule): string {
+	const current = readCurrentSchedule();
+	const nonselected = readNonselectedSchedules();
+
+	// Preserve the existing active schedule alongside the others.
+	const preserved = current.selections.length > 0 ? [current, ...nonselected] : nonselected;
+
+	const name = uniqueScheduleName('Generated 1', 'New ', [current, ...nonselected]);
+
+	const selections = assignColorNumbers(schedule.selections);
+
+	localStorage.setItem(SELECTIONS_KEY, JSON.stringify(selections));
+	localStorage.setItem(NAME_KEY, name);
+	localStorage.setItem(NONSELECTED_KEY, JSON.stringify(preserved));
+
+	return name;
+}

--- a/site/src/lib/schedule-generator/ApplySchedule.ts
+++ b/site/src/lib/schedule-generator/ApplySchedule.ts
@@ -12,7 +12,6 @@
 
 import { resolveSelections, resolveStoredSchedules } from '../course-planner/CourseLoad';
 import { assignColorNumbers } from '../course-planner/Modernization';
-import { uniqueScheduleName } from '../course-planner/ScheduleSelector';
 import type { GeneratedSchedule } from './types';
 import type { ScheduleBlock, StoredSchedule } from '../../types';
 
@@ -35,6 +34,20 @@ function readNonselectedSchedules(): StoredSchedule[] {
 }
 
 /**
+ * The first "Generated N" name not already taken by an existing schedule, so
+ * repeated applies count up (Generated 1, Generated 2, …) rather than stacking
+ * a prefix.
+ */
+function uniqueGeneratedName(existing: StoredSchedule[]): string {
+	const taken = new Set(existing.map((s) => s.scheduleName));
+	let n = 1;
+	while (taken.has(`Generated ${n}`)) {
+		n++;
+	}
+	return `Generated ${n}`;
+}
+
+/**
  * Save `schedule` into the planner as a new named schedule (e.g. "Generated
  * 1"), demoting the user's existing active schedule to a saved one if it had
  * any selections. Returns the name assigned to the new schedule.
@@ -46,7 +59,9 @@ export function applyGeneratedSchedule(schedule: GeneratedSchedule): string {
 	// Preserve the existing active schedule alongside the others.
 	const preserved = current.selections.length > 0 ? [current, ...nonselected] : nonselected;
 
-	const name = uniqueScheduleName('Generated 1', 'New ', [current, ...nonselected]);
+	// Name the new schedule against what is actually being kept, so a discarded
+	// empty active schedule never forces an unnecessary suffix.
+	const name = uniqueGeneratedName(preserved);
 
 	const selections = assignColorNumbers(schedule.selections);
 

--- a/site/src/lib/schedule-generator/Generate.ts
+++ b/site/src/lib/schedule-generator/Generate.ts
@@ -120,37 +120,45 @@ export async function runGeneration(): Promise<void> {
 	const requests = buildRequests(requirements, fullCourses);
 	const ratings = buildRatings(requests);
 
-	const result = generate(requests, constraints, ratings);
+	try {
+		const result = generate(requests, constraints, ratings);
 
-	if (result.schedules.length > 0) {
-		// With optional courses in play, lead with the fullest schedules.
-		if (requests.some((r) => !r.required)) {
-			GeneratorSortStore.set('mostClasses');
+		if (result.schedules.length > 0) {
+			// With optional courses in play, lead with the fullest schedules.
+			if (requests.some((r) => !r.required)) {
+				GeneratorSortStore.set('mostClasses');
+			}
+			GenerationStateStore.set({
+				kind: 'done',
+				schedules: result.schedules,
+				truncated: result.truncated,
+				pinNotices: result.pinNotices
+			});
+			return;
+		}
+
+		// Nothing fits: explain which single constraint to loosen.
+		const hints: RelaxationHint[] = [];
+		for (const relaxation of singleRelaxations(constraints)) {
+			const rerun = generate(requests, relaxation.constraints, ratings, 50);
+			if (rerun.schedules.length > 0) {
+				hints.push({
+					relaxation,
+					scheduleCount: rerun.schedules.length,
+					truncated: rerun.truncated
+				});
+			}
 		}
 		GenerationStateStore.set({
-			kind: 'done',
-			schedules: result.schedules,
-			truncated: result.truncated,
-			pinNotices: result.pinNotices
+			kind: 'noSchedules',
+			hints,
+			coursesWithNoValidSections: result.coursesWithNoValidSections
 		});
-		return;
+	} catch (error) {
+		console.error('Schedule generation failed:', error);
+		GenerationStateStore.set({
+			kind: 'failed',
+			message: 'Something went wrong while generating schedules.'
+		});
 	}
-
-	// Nothing fits: explain which single constraint to loosen.
-	const hints: RelaxationHint[] = [];
-	for (const relaxation of singleRelaxations(constraints)) {
-		const rerun = generate(requests, relaxation.constraints, ratings, 50);
-		if (rerun.schedules.length > 0) {
-			hints.push({
-				relaxation,
-				scheduleCount: rerun.schedules.length,
-				truncated: rerun.truncated
-			});
-		}
-	}
-	GenerationStateStore.set({
-		kind: 'noSchedules',
-		hints,
-		coursesWithNoValidSections: result.coursesWithNoValidSections
-	});
 }

--- a/site/src/lib/schedule-generator/Generate.ts
+++ b/site/src/lib/schedule-generator/Generate.ts
@@ -1,0 +1,156 @@
+/**
+ * This file is part of Jupiterp. For terms of use, please see the file
+ * called LICENSE at the top level of the Jupiterp source tree (online at
+ * https://github.com/atcupps/Jupiterp/LICENSE).
+ * Copyright (C) 2026 Andrew Cupps
+ *
+ * @fileoverview Orchestrates a generation run for the generator page: refetch
+ * full course data, build instructor ratings, run the (pure) engine, and on a
+ * zero-result run compute single-constraint relaxation hints. This is the web
+ * analog of the mobile app's generator view model.
+ */
+
+import { get } from 'svelte/store';
+import type { Course, CoursesConfig } from '@jupiterp/jupiterp';
+import { client } from '$lib/client';
+import { ProfsLookupStore } from '../../stores/CoursePlannerStores';
+import {
+	GenerationStateStore,
+	GeneratorConstraintsStore,
+	GeneratorRequirementsStore,
+	GeneratorSortStore,
+	type GeneratorRequirement,
+	type RelaxationHint
+} from '../../stores/GeneratorStores';
+import { generate } from './ScheduleGenerator';
+import { singleRelaxations } from './Relaxation';
+import type { CourseRequest } from './types';
+
+/** Fetch full, up-to-date courses (with all sections) by course code. */
+async function fetchFullCourses(courseCodes: Set<string>): Promise<Record<string, Course>> {
+	const config: CoursesConfig = { courseCodes };
+	const response = await client.coursesWithSections(config);
+	if (!response.ok() || !response.data) {
+		throw new Error('Could not load course data');
+	}
+	const record: Record<string, Course> = {};
+	for (const course of response.data) {
+		record[course.courseCode] = course;
+	}
+	return record;
+}
+
+/** Build a name -> average-rating map from the loaded instructor lookup. */
+function buildRatings(requests: CourseRequest[]): Map<string, number> {
+	const lookup = get(ProfsLookupStore);
+	const ratings = new Map<string, number>();
+	for (const request of requests) {
+		for (const section of request.course.sections ?? []) {
+			for (const name of section.instructors) {
+				if (ratings.has(name)) {
+					continue;
+				}
+				const instructor = lookup[name];
+				const raw = instructor?.average_rating;
+				if (raw != null) {
+					const value = parseFloat(raw);
+					if (!Number.isNaN(value)) {
+						ratings.set(name, value);
+					}
+				}
+			}
+		}
+	}
+	return ratings;
+}
+
+/** Build engine requests from the wishlist using refetched full courses. */
+function buildRequests(
+	requirements: GeneratorRequirement[],
+	fullCourses: Record<string, Course>
+): CourseRequest[] {
+	const requests: CourseRequest[] = [];
+	for (const requirement of requirements) {
+		const course = fullCourses[requirement.course.courseCode];
+		if (course) {
+			requests.push({
+				course,
+				required: requirement.required,
+				pin: requirement.pin
+			});
+		}
+	}
+	return requests;
+}
+
+/**
+ * Run a full generation using the current wishlist, constraints, and loaded
+ * instructor ratings, updating `GenerationStateStore` with the outcome.
+ */
+export async function runGeneration(): Promise<void> {
+	const requirements = get(GeneratorRequirementsStore);
+	if (requirements.length === 0) {
+		return;
+	}
+	const constraints = get(GeneratorConstraintsStore);
+
+	GenerationStateStore.set({ kind: 'loading' });
+
+	let fullCourses: Record<string, Course>;
+	try {
+		const courseCodes = new Set(requirements.map((r) => r.course.courseCode));
+		fullCourses = await fetchFullCourses(courseCodes);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : 'Could not load courses';
+		GenerationStateStore.set({ kind: 'failed', message });
+		return;
+	}
+
+	const missing = requirements
+		.filter((r) => !fullCourses[r.course.courseCode])
+		.map((r) => r.course.courseCode);
+	if (missing.length > 0) {
+		GenerationStateStore.set({
+			kind: 'failed',
+			message: `Couldn't find: ${missing.join(', ')}`
+		});
+		return;
+	}
+
+	const requests = buildRequests(requirements, fullCourses);
+	const ratings = buildRatings(requests);
+
+	const result = generate(requests, constraints, ratings);
+
+	if (result.schedules.length > 0) {
+		// With optional courses in play, lead with the fullest schedules.
+		if (requests.some((r) => !r.required)) {
+			GeneratorSortStore.set('mostClasses');
+		}
+		GenerationStateStore.set({
+			kind: 'done',
+			schedules: result.schedules,
+			truncated: result.truncated,
+			pinNotices: result.pinNotices
+		});
+		return;
+	}
+
+	// Nothing fits: explain which single constraint to loosen.
+	const hints: RelaxationHint[] = [];
+	for (const relaxation of singleRelaxations(constraints)) {
+		const rerun = generate(requests, relaxation.constraints, ratings, 50);
+		if (rerun.schedules.length > 0) {
+			hints.push({
+				relaxation,
+				scheduleCount: rerun.schedules.length,
+				truncated: rerun.truncated
+			});
+		}
+	}
+	GenerationStateStore.set({
+		kind: 'noSchedules',
+		hints,
+		coursesWithNoValidSections: result.coursesWithNoValidSections
+	});
+}

--- a/site/src/lib/schedule-generator/Generate.ts
+++ b/site/src/lib/schedule-generator/Generate.ts
@@ -26,6 +26,14 @@ import { generate } from './ScheduleGenerator';
 import { singleRelaxations } from './Relaxation';
 import type { CourseRequest } from './types';
 
+/**
+ * Node budget for relaxation probes. Each zero-result generation re-runs the
+ * engine once per active constraint; capping the search keeps that bounded and
+ * off the critical path. A probe that exceeds this budget may under-report or
+ * omit a hint — acceptable, since hints are advisory.
+ */
+const RELAXATION_MAX_NODES = 50_000;
+
 /** Fetch full, up-to-date courses (with all sections) by course code. */
 async function fetchFullCourses(courseCodes: Set<string>): Promise<Record<string, Course>> {
 	const config: CoursesConfig = { courseCodes };
@@ -140,7 +148,7 @@ export async function runGeneration(): Promise<void> {
 		// Nothing fits: explain which single constraint to loosen.
 		const hints: RelaxationHint[] = [];
 		for (const relaxation of singleRelaxations(constraints)) {
-			const rerun = generate(requests, relaxation.constraints, ratings, 50);
+			const rerun = generate(requests, relaxation.constraints, ratings, 50, RELAXATION_MAX_NODES);
 			if (rerun.schedules.length > 0) {
 				hints.push({
 					relaxation,

--- a/site/src/lib/schedule-generator/GeneratorFormat.ts
+++ b/site/src/lib/schedule-generator/GeneratorFormat.ts
@@ -42,6 +42,22 @@ export function minutesToLabel(minutes: number): string {
 	return `${hour12}:${mm} ${period}`;
 }
 
+/**
+ * Build dropdown options for a time-of-day selector, in minutes since
+ * midnight, from `startHour` to `endHour` inclusive at `stepMinutes` spacing.
+ */
+export function timeSlotOptions(
+	startHour = 7,
+	endHour = 22,
+	stepMinutes = 30
+): { value: string; label: string }[] {
+	const options: { value: string; label: string }[] = [];
+	for (let m = startHour * 60; m <= endHour * 60; m += stepMinutes) {
+		options.push({ value: String(m), label: minutesToLabel(m) });
+	}
+	return options;
+}
+
 /** Format minutes-since-midnight as a 24-hour `<input type="time">` value. */
 export function minutesToTimeInput(minutes: number | null): string {
 	if (minutes === null) {

--- a/site/src/lib/schedule-generator/GeneratorFormat.ts
+++ b/site/src/lib/schedule-generator/GeneratorFormat.ts
@@ -1,0 +1,106 @@
+/**
+ * This file is part of Jupiterp. For terms of use, please see the file
+ * called LICENSE at the top level of the Jupiterp source tree (online at
+ * https://github.com/atcupps/Jupiterp/LICENSE).
+ * Copyright (C) 2026 Andrew Cupps
+ *
+ * @fileoverview Presentation helpers for the schedule generator: converting
+ * between minutes-since-midnight and time-input strings, labelling days,
+ * overridden filters, and relaxation hints.
+ */
+
+import type { EngineDay, OverriddenFilter, Relaxation } from './types';
+
+/** Days of the week in display order. */
+export const ENGINE_DAYS: EngineDay[] = ['M', 'Tu', 'W', 'Th', 'F', 'Sa', 'Su'];
+
+const DAY_LONG: Record<EngineDay, string> = {
+	M: 'Monday',
+	Tu: 'Tuesday',
+	W: 'Wednesday',
+	Th: 'Thursday',
+	F: 'Friday',
+	Sa: 'Saturday',
+	Su: 'Sunday'
+};
+
+/** Full day name, e.g. "Friday". */
+export function engineDayLong(day: EngineDay): string {
+	return DAY_LONG[day];
+}
+
+/** Format minutes-since-midnight as a 12-hour time, e.g. 570 -> "9:00 AM". */
+export function minutesToLabel(minutes: number): string {
+	const hour24 = Math.floor(minutes / 60);
+	const minute = minutes % 60;
+	const period = hour24 < 12 ? 'AM' : 'PM';
+	let hour12 = hour24 % 12;
+	if (hour12 === 0) {
+		hour12 = 12;
+	}
+	const mm = minute.toString().padStart(2, '0');
+	return `${hour12}:${mm} ${period}`;
+}
+
+/** Format minutes-since-midnight as a 24-hour `<input type="time">` value. */
+export function minutesToTimeInput(minutes: number | null): string {
+	if (minutes === null) {
+		return '';
+	}
+	const hh = Math.floor(minutes / 60)
+		.toString()
+		.padStart(2, '0');
+	const mm = (minutes % 60).toString().padStart(2, '0');
+	return `${hh}:${mm}`;
+}
+
+/** Parse an `<input type="time">` value ("HH:MM") to minutes, or null. */
+export function timeInputToMinutes(value: string): number | null {
+	if (!value) {
+		return null;
+	}
+	const parts = value.split(':');
+	if (parts.length !== 2) {
+		return null;
+	}
+	const hours = parseInt(parts[0], 10);
+	const minutes = parseInt(parts[1], 10);
+	if (Number.isNaN(hours) || Number.isNaN(minutes)) {
+		return null;
+	}
+	return hours * 60 + minutes;
+}
+
+/** A short, human-readable label for an overridden per-section filter. */
+export function overriddenFilterLabel(filter: OverriddenFilter): string {
+	switch (filter) {
+		case 'earliestStart':
+			return 'starts earlier than your earliest-start time';
+		case 'latestEnd':
+			return 'ends later than your latest-end time';
+		case 'dayOff':
+			return 'meets on a day you marked off';
+		case 'openSeats':
+			return 'has no open seats';
+	}
+}
+
+/** A short call-to-action describing a single constraint relaxation. */
+export function relaxationLabel(relaxation: Relaxation): string {
+	switch (relaxation.kind) {
+		case 'earliestStart':
+			return 'Allow earlier classes';
+		case 'latestEnd':
+			return 'Allow later classes';
+		case 'dayOff':
+			return relaxation.day
+				? `Allow ${engineDayLong(relaxation.day)} classes`
+				: 'Allow classes on a day off';
+		case 'openSeats':
+			return 'Include full (closed) sections';
+		case 'minGap':
+			return 'Remove the minimum gap between classes';
+		case 'minCredits':
+			return 'Allow fewer credits';
+	}
+}

--- a/site/src/lib/schedule-generator/Relaxation.test.ts
+++ b/site/src/lib/schedule-generator/Relaxation.test.ts
@@ -1,0 +1,78 @@
+/**
+ * This file is part of Jupiterp. For terms of use, please see the file
+ * called LICENSE at the top level of the Jupiterp source tree (online at
+ * https://github.com/atcupps/Jupiterp/LICENSE).
+ * Copyright (C) 2026 Andrew Cupps
+ *
+ * @fileoverview Unit tests for constraint relaxation.
+ */
+
+import { describe, expect, test } from '@jest/globals';
+import { singleRelaxations } from './Relaxation';
+import { defaultConstraints } from './types';
+import type { EngineDay } from './types';
+
+describe('singleRelaxations', () => {
+	test('lists one relaxation per active constraint', () => {
+		const daysOff = new Set<EngineDay>(['M', 'F']);
+		const relaxations = singleRelaxations({
+			earliestStartMinutes: 9 * 60,
+			latestEndMinutes: 17 * 60,
+			daysOff,
+			onlyOpenSeats: true,
+			minGapMinutes: 15,
+			minCredits: 12
+		});
+		const kinds = relaxations.map((r) => r.kind).sort();
+		// earliestStart, latestEnd, dayOff x2, openSeats, minGap, minCredits
+		expect(relaxations).toHaveLength(7);
+		expect(kinds).toEqual([
+			'dayOff',
+			'dayOff',
+			'earliestStart',
+			'latestEnd',
+			'minCredits',
+			'minGap',
+			'openSeats'
+		]);
+	});
+
+	test('relaxes each day off individually', () => {
+		const relaxations = singleRelaxations({
+			...defaultConstraints(),
+			daysOff: new Set<EngineDay>(['M', 'F'])
+		});
+		const dayOffs = relaxations.filter((r) => r.kind === 'dayOff');
+		expect(dayOffs.map((r) => r.day).sort()).toEqual(['F', 'M']);
+		// Each relaxation removes exactly that one day.
+		const forM = dayOffs.find((r) => r.day === 'M');
+		expect(forM?.constraints.daysOff.has('M')).toBe(false);
+		expect(forM?.constraints.daysOff.has('F')).toBe(true);
+	});
+
+	test('min credits listed as a relaxation', () => {
+		const relaxations = singleRelaxations({
+			...defaultConstraints(),
+			onlyOpenSeats: false,
+			minCredits: 15
+		});
+		expect(relaxations).toHaveLength(1);
+		expect(relaxations[0].kind).toBe('minCredits');
+		expect(relaxations[0].constraints.minCredits).toBeNull();
+	});
+
+	test('no relaxations for unconstrained input', () => {
+		const relaxations = singleRelaxations({
+			...defaultConstraints(),
+			onlyOpenSeats: false
+		});
+		expect(relaxations).toHaveLength(0);
+	});
+
+	test('only-open-seats is its own relaxation', () => {
+		const relaxations = singleRelaxations(defaultConstraints());
+		expect(relaxations).toHaveLength(1);
+		expect(relaxations[0].kind).toBe('openSeats');
+		expect(relaxations[0].constraints.onlyOpenSeats).toBe(false);
+	});
+});

--- a/site/src/lib/schedule-generator/Relaxation.ts
+++ b/site/src/lib/schedule-generator/Relaxation.ts
@@ -1,0 +1,74 @@
+/**
+ * This file is part of Jupiterp. For terms of use, please see the file
+ * called LICENSE at the top level of the Jupiterp source tree (online at
+ * https://github.com/atcupps/Jupiterp/LICENSE).
+ * Copyright (C) 2026 Andrew Cupps
+ *
+ * @fileoverview When nothing fits, the generator loosens one constraint at a
+ * time and re-runs to report how many schedules each single change would
+ * unlock. This module enumerates those single relaxations. Ported from the
+ * mobile app's relaxation logic.
+ */
+
+import type { HardConstraints, Relaxation } from './types';
+
+/**
+ * Every constraint set that differs from `constraints` by removing exactly
+ * one restriction. A day off is relaxed individually so each blocked day
+ * becomes its own actionable suggestion.
+ */
+export function singleRelaxations(constraints: HardConstraints): Relaxation[] {
+	const relaxations: Relaxation[] = [];
+
+	if (constraints.earliestStartMinutes !== null) {
+		relaxations.push({
+			kind: 'earliestStart',
+			day: null,
+			constraints: { ...constraints, earliestStartMinutes: null }
+		});
+	}
+
+	if (constraints.latestEndMinutes !== null) {
+		relaxations.push({
+			kind: 'latestEnd',
+			day: null,
+			constraints: { ...constraints, latestEndMinutes: null }
+		});
+	}
+
+	for (const day of constraints.daysOff) {
+		const daysOff = new Set(constraints.daysOff);
+		daysOff.delete(day);
+		relaxations.push({
+			kind: 'dayOff',
+			day,
+			constraints: { ...constraints, daysOff }
+		});
+	}
+
+	if (constraints.onlyOpenSeats) {
+		relaxations.push({
+			kind: 'openSeats',
+			day: null,
+			constraints: { ...constraints, onlyOpenSeats: false }
+		});
+	}
+
+	if (constraints.minGapMinutes > 0) {
+		relaxations.push({
+			kind: 'minGap',
+			day: null,
+			constraints: { ...constraints, minGapMinutes: 0 }
+		});
+	}
+
+	if (constraints.minCredits !== null) {
+		relaxations.push({
+			kind: 'minCredits',
+			day: null,
+			constraints: { ...constraints, minCredits: null }
+		});
+	}
+
+	return relaxations;
+}

--- a/site/src/lib/schedule-generator/ScheduleGenerator.test.ts
+++ b/site/src/lib/schedule-generator/ScheduleGenerator.test.ts
@@ -1,0 +1,357 @@
+/**
+ * This file is part of Jupiterp. For terms of use, please see the file
+ * called LICENSE at the top level of the Jupiterp source tree (online at
+ * https://github.com/atcupps/Jupiterp/LICENSE).
+ * Copyright (C) 2026 Andrew Cupps
+ *
+ * @fileoverview Unit tests for the schedule generator engine.
+ */
+
+import { describe, expect, test } from '@jest/globals';
+import type { ClassMeeting, Course, Section } from '@jupiterp/jupiterp';
+import { generate, generateFromCourses } from './ScheduleGenerator';
+import { defaultConstraints } from './types';
+import type { CourseRequest, HardConstraints, SectionPin } from './types';
+
+// --- Fixture builders ------------------------------------------------------
+
+/** Decimal-hour helper: `hours(9, 50)` is 9:50 AM. */
+function hours(h: number, m = 0): number {
+	return h + m / 60;
+}
+
+/** A single timed in-person meeting. */
+function meeting(days: string, start: number, end: number): ClassMeeting {
+	return {
+		classtime: { days, start, end },
+		location: { building: 'TST', room: '101' }
+	};
+}
+
+function section(
+	courseCode: string,
+	sectionCode: string,
+	meetings: ClassMeeting[],
+	opts: { openSeats?: number; instructors?: string[] } = {}
+): Section {
+	return {
+		courseCode,
+		sectionCode,
+		instructors: opts.instructors ?? ['Prof ' + sectionCode],
+		meetings,
+		openSeats: opts.openSeats ?? 30,
+		totalSeats: 30,
+		waitlist: 0,
+		holdfile: null
+	};
+}
+
+function course(
+	courseCode: string,
+	sections: Section[],
+	opts: { minCredits?: number; maxCredits?: number | null } = {}
+): Course {
+	return {
+		courseCode,
+		name: courseCode + ' Name',
+		minCredits: opts.minCredits ?? 3,
+		maxCredits: opts.maxCredits ?? null,
+		genEds: null,
+		conditions: null,
+		description: null,
+		sections
+	};
+}
+
+function req(c: Course, required: boolean, pin: SectionPin = { kind: 'none' }): CourseRequest {
+	return { course: c, required, pin };
+}
+
+// --- Conflict & ordering ---------------------------------------------------
+
+describe('conflict and ordering', () => {
+	test('excludes conflicting combinations', () => {
+		const aaa = course('AAA101', [section('AAA101', '0101', [meeting('MWF', 9, 10)])]);
+		const bbb = course('BBB200', [
+			section('BBB200', '0301', [meeting('MWF', 9, 10)]),
+			section('BBB200', '0401', [meeting('MWF', 11, 12)])
+		]);
+		const result = generateFromCourses([aaa, bbb], defaultConstraints());
+
+		expect(result.schedules).toHaveLength(1);
+		const usesConflicting = result.schedules.some((sch) =>
+			sch.selections.some(
+				(s) => s.course.courseCode === 'BBB200' && s.section.sectionCode === '0301'
+			)
+		);
+		expect(usesConflicting).toBe(false);
+	});
+
+	test('selections follow requested course order', () => {
+		const zzz = course('ZZZ200', [
+			section('ZZZ200', '0101', [meeting('MWF', 9, 10)]),
+			section('ZZZ200', '0201', [meeting('MWF', 13, 14)])
+		]);
+		const aaa = course('AAA101', [section('AAA101', '0101', [meeting('TuTh', 9, 10)])]);
+		// ZZZ has more candidates, so fail-first orders AAA first internally.
+		const result = generate([req(zzz, true), req(aaa, true)], defaultConstraints());
+
+		expect(result.schedules.length).toBeGreaterThan(0);
+		for (const sch of result.schedules) {
+			const codes = sch.selections.map((s) => s.course.courseCode);
+			expect(codes).toEqual(['ZZZ200', 'AAA101']);
+		}
+	});
+});
+
+// --- Per-section filters ---------------------------------------------------
+
+describe('per-section filters', () => {
+	test('only-open-seats filters full sections', () => {
+		const c = course('AAA101', [
+			section('AAA101', '0101', [meeting('MWF', 9, 10)], {
+				openSeats: 0
+			}),
+			section('AAA101', '0201', [meeting('MWF', 13, 14)], {
+				openSeats: 5
+			})
+		]);
+
+		const closed = generateFromCourses([c], defaultConstraints());
+		expect(closed.schedules).toHaveLength(1);
+		expect(closed.schedules[0].selections[0].section.sectionCode).toBe('0201');
+
+		const open = generateFromCourses([c], {
+			...defaultConstraints(),
+			onlyOpenSeats: false
+		});
+		expect(open.schedules).toHaveLength(2);
+	});
+
+	test('time window filters sections', () => {
+		const c = course('AAA101', [
+			section('AAA101', '0101', [meeting('MWF', 8, 9)]),
+			section('AAA101', '0201', [meeting('MWF', 11, 12)]),
+			section('AAA101', '0301', [meeting('MWF', 16, 17)])
+		]);
+		const constraints: HardConstraints = {
+			...defaultConstraints(),
+			earliestStartMinutes: 10 * 60,
+			latestEndMinutes: 15 * 60
+		};
+		const result = generateFromCourses([c], constraints);
+		expect(result.schedules).toHaveLength(1);
+		expect(result.schedules[0].selections[0].section.sectionCode).toBe('0201');
+	});
+
+	test('days off filter sections', () => {
+		const c = course('AAA101', [
+			section('AAA101', '0101', [meeting('MWF', 9, 10)]),
+			section('AAA101', '0201', [meeting('TuTh', 9, 10)])
+		]);
+		const result = generateFromCourses([c], {
+			...defaultConstraints(),
+			daysOff: new Set(['F'])
+		});
+		expect(result.schedules).toHaveLength(1);
+		expect(result.schedules[0].selections[0].section.sectionCode).toBe('0201');
+	});
+
+	test('min gap treats back-to-back as conflict', () => {
+		const a = course('AAA101', [section('AAA101', '0101', [meeting('MWF', 9, 10)])]);
+		const b = course('BBB200', [section('BBB200', '0101', [meeting('MWF', 10, 11)])]);
+
+		const noGap = generateFromCourses([a, b], defaultConstraints());
+		expect(noGap.schedules).toHaveLength(1);
+
+		const withGap = generateFromCourses([a, b], {
+			...defaultConstraints(),
+			minGapMinutes: 30
+		});
+		expect(withGap.schedules).toHaveLength(0);
+	});
+
+	test('async sections always fit', () => {
+		const timed = course('AAA101', [section('AAA101', '0101', [meeting('MWF', 9, 10)])]);
+		const async = course('BBB200', [section('BBB200', '0101', ['OnlineAsync'])]);
+		const result = generateFromCourses([timed, async], defaultConstraints());
+		expect(result.schedules).toHaveLength(1);
+		expect(result.schedules[0].selections).toHaveLength(2);
+	});
+});
+
+// --- Bounds ----------------------------------------------------------------
+
+describe('bounds', () => {
+	test('truncates at max results', () => {
+		const c = course('AAA101', [
+			section('AAA101', '0101', [meeting('M', 9, 10)]),
+			section('AAA101', '0201', [meeting('M', 11, 12)]),
+			section('AAA101', '0301', [meeting('M', 13, 14)]),
+			section('AAA101', '0401', [meeting('M', 15, 16)]),
+			section('AAA101', '0501', [meeting('M', 17, 18)])
+		]);
+		const result = generateFromCourses([c], defaultConstraints(), new Map(), 3);
+		expect(result.schedules).toHaveLength(3);
+		expect(result.truncated).toBe(true);
+	});
+});
+
+// --- Optional courses ------------------------------------------------------
+
+describe('optional courses', () => {
+	test('optional course is dropped when it conflicts', () => {
+		const a = course('AAA101', [section('AAA101', '0101', [meeting('MWF', 9, 10)])]);
+		const b = course('BBB200', [section('BBB200', '0101', [meeting('MWF', 9, 10)])]);
+		const result = generate([req(a, true), req(b, false)], defaultConstraints());
+		expect(result.schedules).toHaveLength(1);
+		expect(result.schedules[0].selections).toHaveLength(1);
+		expect(result.schedules[0].selections[0].course.courseCode).toBe('AAA101');
+	});
+
+	test('optional courses generate every subset', () => {
+		const a = course('AAA101', [section('AAA101', '0101', [meeting('M', 9, 10)])]);
+		const b = course('BBB200', [section('BBB200', '0101', [meeting('M', 11, 12)])]);
+		const c = course('CCC300', [section('CCC300', '0101', [meeting('M', 13, 14)])]);
+		const result = generate([req(a, true), req(b, false), req(c, false)], defaultConstraints());
+		const sizes = result.schedules.map((s) => s.selections.length).sort();
+		expect(sizes).toEqual([1, 2, 2, 3]);
+	});
+
+	test('required course with no sections blocks; optional does not', () => {
+		const valid = course('AAA101', [section('AAA101', '0101', [meeting('MWF', 9, 10)])]);
+		const empty = course('BBB200', []);
+
+		const blocked = generate([req(valid, true), req(empty, true)], defaultConstraints());
+		expect(blocked.schedules).toHaveLength(0);
+		expect(blocked.coursesWithNoValidSections).toContain('BBB200');
+
+		const dropped = generate([req(valid, true), req(empty, false)], defaultConstraints());
+		expect(dropped.schedules).toHaveLength(1);
+		expect(dropped.coursesWithNoValidSections).toHaveLength(0);
+	});
+});
+
+// --- Pins ------------------------------------------------------------------
+
+describe('pins', () => {
+	test('pin by section restricts to that section', () => {
+		const c = course('AAA101', [
+			section('AAA101', '0101', [meeting('MWF', 9, 10)]),
+			section('AAA101', '0201', [meeting('MWF', 13, 14)])
+		]);
+		const result = generate(
+			[req(c, true, { kind: 'bySection', sectionCode: '0201' })],
+			defaultConstraints()
+		);
+		expect(result.schedules).toHaveLength(1);
+		expect(result.schedules[0].selections[0].section.sectionCode).toBe('0201');
+	});
+
+	test('pin by instructor keeps only that professor', () => {
+		const c = course('AAA101', [
+			section('AAA101', '0101', [meeting('MWF', 9, 10)], {
+				instructors: ['Dr. A']
+			}),
+			section('AAA101', '0201', [meeting('MWF', 13, 14)], {
+				instructors: ['Dr. B']
+			})
+		]);
+		const result = generate(
+			[req(c, true, { kind: 'byInstructor', name: 'Dr. B' })],
+			defaultConstraints()
+		);
+		expect(result.schedules).toHaveLength(1);
+		expect(result.schedules[0].selections[0].section.sectionCode).toBe('0201');
+	});
+
+	test('pin wins over filter and reports the override', () => {
+		const c = course('AAA101', [section('AAA101', '0101', [meeting('MWF', 9, 10)])]);
+		const result = generate([req(c, true, { kind: 'bySection', sectionCode: '0101' })], {
+			...defaultConstraints(),
+			earliestStartMinutes: 10 * 60
+		});
+		expect(result.schedules).toHaveLength(1);
+		expect(result.pinNotices).toHaveLength(1);
+		expect(result.pinNotices[0].overriddenFilters).toContain('earliestStart');
+	});
+});
+
+// --- Credits ---------------------------------------------------------------
+
+describe('credits', () => {
+	test('min credits excludes too-light schedules', () => {
+		const a = course('AAA101', [section('AAA101', '0101', [meeting('M', 9, 10)])], {
+			minCredits: 3
+		});
+		const b = course('BBB200', [section('BBB200', '0101', [meeting('M', 11, 12)])], {
+			minCredits: 3
+		});
+		const result = generate([req(a, true), req(b, false)], {
+			...defaultConstraints(),
+			minCredits: 6
+		});
+		expect(result.schedules).toHaveLength(1);
+		expect(result.schedules[0].selections).toHaveLength(2);
+	});
+});
+
+// --- Metrics ---------------------------------------------------------------
+
+describe('metrics', () => {
+	test('computes metrics', () => {
+		const a = course('AAA101', [section('AAA101', '0101', [meeting('MWF', 9, 10)])], {
+			minCredits: 3
+		});
+		const b = course('BBB200', [section('BBB200', '0101', [meeting('MWF', 11, 12)])], {
+			minCredits: 4
+		});
+		const ratings = new Map([['Prof 0101', 4]]);
+		const result = generateFromCourses([a, b], defaultConstraints(), ratings);
+		const m = result.schedules[0].metrics;
+
+		expect(m.sectionCount).toBe(2);
+		expect(m.minCredits).toBe(7);
+		expect(m.daysWithClasses).toBe(3);
+		expect(m.earliestStartMinutes).toBe(540);
+		expect(m.latestEndMinutes).toBe(720);
+		expect(m.avgInstructorRating).toBe(4);
+		expect(m.ratedSectionCount).toBe(2);
+	});
+
+	test('gap counts breaks within and across courses', () => {
+		const a = course('AAA101', [section('AAA101', '0101', [meeting('MWF', 9, 10)])]);
+		const b = course('BBB200', [section('BBB200', '0101', [meeting('MWF', 11, 12)])]);
+		const result = generateFromCourses([a, b], defaultConstraints());
+		// 60-minute gap on each of M, W, F.
+		expect(result.schedules[0].metrics.totalGapMinutes).toBe(180);
+	});
+
+	test('counts short passing periods', () => {
+		const a = course('AAA101', [
+			section('AAA101', '0101', [meeting('MWF', hours(9), hours(9, 50))])
+		]);
+		const b = course('BBB200', [
+			section('BBB200', '0101', [meeting('MWF', hours(10), hours(10, 50))])
+		]);
+		const result = generateFromCourses([a, b], defaultConstraints());
+		// 10-minute passing period on each of M, W, F.
+		expect(result.schedules[0].metrics.totalGapMinutes).toBe(30);
+	});
+
+	test('single meeting day has no gap', () => {
+		const a = course('AAA101', [section('AAA101', '0101', [meeting('M', 9, 10)])]);
+		const result = generateFromCourses([a], defaultConstraints());
+		expect(result.schedules[0].metrics.totalGapMinutes).toBe(0);
+	});
+
+	test('untimed schedule has null time metrics', () => {
+		const async = course('AAA101', [section('AAA101', '0101', ['OnlineAsync'])]);
+		const result = generateFromCourses([async], defaultConstraints());
+		const m = result.schedules[0].metrics;
+		expect(m.earliestStartMinutes).toBeNull();
+		expect(m.latestEndMinutes).toBeNull();
+		expect(m.daysWithClasses).toBe(0);
+		expect(m.totalGapMinutes).toBe(0);
+	});
+});

--- a/site/src/lib/schedule-generator/ScheduleGenerator.test.ts
+++ b/site/src/lib/schedule-generator/ScheduleGenerator.test.ts
@@ -195,6 +195,18 @@ describe('bounds', () => {
 		expect(result.schedules).toHaveLength(3);
 		expect(result.truncated).toBe(true);
 	});
+
+	test('honors a custom max-nodes budget', () => {
+		const c = course('AAA101', [
+			section('AAA101', '0101', [meeting('M', 9, 10)]),
+			section('AAA101', '0201', [meeting('M', 11, 12)]),
+			section('AAA101', '0301', [meeting('M', 13, 14)])
+		]);
+		// maxNodes = 1: the second explored candidate trips the budget.
+		const result = generate([req(c, true)], defaultConstraints(), new Map(), 1000, 1);
+		expect(result.truncated).toBe(true);
+		expect(result.schedules.length).toBeLessThan(3);
+	});
 });
 
 // --- Optional courses ------------------------------------------------------

--- a/site/src/lib/schedule-generator/ScheduleGenerator.ts
+++ b/site/src/lib/schedule-generator/ScheduleGenerator.ts
@@ -1,0 +1,448 @@
+/**
+ * This file is part of Jupiterp. For terms of use, please see the file
+ * called LICENSE at the top level of the Jupiterp source tree (online at
+ * https://github.com/atcupps/Jupiterp/LICENSE).
+ * Copyright (C) 2026 Andrew Cupps
+ *
+ * @fileoverview The automatic schedule generator engine: a pure, synchronous,
+ * constraint-filtered depth-first search with backtracking and fail-first
+ * variable ordering. Given a list of `CourseRequest`s plus `HardConstraints`,
+ * it returns every conflict-free way to pick one section per course, with
+ * precomputed metrics for ranking. Ported from the mobile app's
+ * `ScheduleGenerator`.
+ */
+
+import type { Course, Section } from '@jupiterp/jupiterp';
+import type { ScheduleSelection } from '../../types';
+import { noDifferences } from '../course-planner/Schedule';
+import type {
+	CourseRequest,
+	EngineDay,
+	GeneratedSchedule,
+	GenerationResult,
+	HardConstraints,
+	OverriddenFilter,
+	PinNotice,
+	ScheduleMetrics
+} from './types';
+
+/** Default cap on the number of schedules returned. */
+export const DEFAULT_MAX_RESULTS = 200;
+
+/** Hard cap on explored search nodes so degenerate inputs can't hang. */
+const MAX_NODES = 500_000;
+
+/** A single day/time block, in integer minutes since midnight. */
+interface MinuteSlot {
+	day: EngineDay;
+	start: number;
+	end: number;
+}
+
+/** A course section paired with its conflict-detection time slots. */
+interface Candidate {
+	course: Course;
+	section: Section;
+	slots: MinuteSlot[];
+}
+
+/** A course's surviving candidates, plus whether the course is optional. */
+interface CourseCandidates {
+	candidates: Candidate[];
+	optional: boolean;
+}
+
+/**
+ * Two slots conflict only when they share a day and their [start, end)
+ * intervals overlap once expanded by the required gap.
+ */
+function slotsConflict(a: MinuteSlot, b: MinuteSlot, minGapMinutes: number): boolean {
+	return a.day === b.day && a.start - minGapMinutes < b.end && a.end + minGapMinutes > b.start;
+}
+
+/**
+ * Two-letter day codes (Tu, Th, Sa, Su) are matched before the single-letter
+ * ones so "Th" is never read as "T" + "h".
+ */
+const DAY_TOKENS: ReadonlyArray<readonly [string, EngineDay]> = [
+	['Tu', 'Tu'],
+	['Th', 'Th'],
+	['Sa', 'Sa'],
+	['Su', 'Su'],
+	['M', 'M'],
+	['W', 'W'],
+	['F', 'F']
+];
+
+/**
+ * Parse a day code into the exact days it represents, keeping all seven days
+ * of the week distinct (unlike the planner's renderer).
+ * @param days A day code, e.g. "MWF" or "TuTh".
+ */
+function parseDaysExact(days: string): EngineDay[] {
+	const result: EngineDay[] = [];
+	let i = 0;
+	while (i < days.length) {
+		let matched = false;
+		for (const [token, day] of DAY_TOKENS) {
+			if (days.startsWith(token, i)) {
+				result.push(day);
+				i += token.length;
+				matched = true;
+				break;
+			}
+		}
+		if (!matched) {
+			i += 1;
+		}
+	}
+	return result;
+}
+
+/**
+ * Flatten a section's meetings into integer-minute time slots. Only timed
+ * (object) meetings produce slots; string meetings (async, TBA, unknown)
+ * produce none, which is why async sections never conflict with anything.
+ */
+function minuteSlots(section: Section): MinuteSlot[] {
+	const result: MinuteSlot[] = [];
+	for (const meeting of section.meetings) {
+		if (typeof meeting === 'string') {
+			continue;
+		}
+		const start = Math.round(meeting.classtime.start * 60);
+		const end = Math.round(meeting.classtime.end * 60);
+		for (const day of parseDaysExact(meeting.classtime.days)) {
+			result.push({ day, start, end });
+		}
+	}
+	return result;
+}
+
+/** Narrow a request's course to the sections selected by its pin. */
+function pinnedSections(request: CourseRequest): Section[] {
+	const sections = request.course.sections ?? [];
+	const pin = request.pin;
+	switch (pin.kind) {
+		case 'none':
+			return sections;
+		case 'bySection':
+			return sections.filter((s) => s.sectionCode === pin.sectionCode);
+		case 'byInstructor':
+			return sections.filter((s) => s.instructors.includes(pin.name));
+	}
+}
+
+/** Whether a candidate survives the per-section hard constraints. */
+function candidatePasses(candidate: Candidate, constraints: HardConstraints): boolean {
+	if (constraints.onlyOpenSeats && candidate.section.openSeats <= 0) {
+		return false;
+	}
+	const earliest = constraints.earliestStartMinutes;
+	const latest = constraints.latestEndMinutes;
+	return candidate.slots.every((slot) => {
+		if (constraints.daysOff.has(slot.day)) {
+			return false;
+		}
+		if (earliest !== null && slot.start < earliest) {
+			return false;
+		}
+		if (latest !== null && slot.end > latest) {
+			return false;
+		}
+		return true;
+	});
+}
+
+/** Which per-section filters a (pinned) candidate violates. */
+function overriddenFilters(candidate: Candidate, constraints: HardConstraints): OverriddenFilter[] {
+	const result: OverriddenFilter[] = [];
+	if (constraints.onlyOpenSeats && candidate.section.openSeats <= 0) {
+		result.push('openSeats');
+	}
+	const earliest = constraints.earliestStartMinutes;
+	if (earliest !== null && candidate.slots.some((s) => s.start < earliest)) {
+		result.push('earliestStart');
+	}
+	const latest = constraints.latestEndMinutes;
+	if (latest !== null && candidate.slots.some((s) => s.end > latest)) {
+		result.push('latestEnd');
+	}
+	if (candidate.slots.some((s) => constraints.daysOff.has(s.day))) {
+		result.push('dayOff');
+	}
+	return result;
+}
+
+/** Build a planner `ScheduleSelection` from an engine candidate. */
+function toScheduleSelection(candidate: Candidate, colorNumber: number): ScheduleSelection {
+	const course = candidate.course;
+	return {
+		course: {
+			courseCode: course.courseCode,
+			name: course.name,
+			minCredits: course.minCredits,
+			maxCredits: course.maxCredits,
+			description: course.description,
+			genEds: course.genEds,
+			conditions: course.conditions
+		},
+		section: candidate.section,
+		hover: false,
+		differences: noDifferences(),
+		colorNumber
+	};
+}
+
+/** Sum of the minimum credits across a combination of candidates. */
+function sumMinCredits(combo: Candidate[]): number {
+	return combo.reduce((total, c) => total + c.course.minCredits, 0);
+}
+
+/** Compute, once, the ranking metrics for a found combination. */
+function computeMetrics(combo: Candidate[], ratings: Map<string, number>): ScheduleMetrics {
+	const slots = combo.flatMap((c) => c.slots);
+
+	const slotsByDay = new Map<EngineDay, MinuteSlot[]>();
+	for (const slot of slots) {
+		const existing = slotsByDay.get(slot.day);
+		if (existing) {
+			existing.push(slot);
+		} else {
+			slotsByDay.set(slot.day, [slot]);
+		}
+	}
+
+	// Idle minutes between classes on each day, summed across the week. A
+	// running max-end keeps nested or multi-meeting sections from producing
+	// negative or double-counted gaps.
+	let totalGapMinutes = 0;
+	for (const daySlots of slotsByDay.values()) {
+		const sorted = [...daySlots].sort((a, b) => a.start - b.start);
+		let coveredUntil = sorted[0].end;
+		for (let i = 1; i < sorted.length; i++) {
+			const slot = sorted[i];
+			if (slot.start > coveredUntil) {
+				totalGapMinutes += slot.start - coveredUntil;
+			}
+			coveredUntil = Math.max(coveredUntil, slot.end);
+		}
+	}
+
+	// A section's rating is the mean of its rated instructors; unrated
+	// sections are excluded from the average rather than counted as zero.
+	const sectionRatings: number[] = [];
+	for (const candidate of combo) {
+		const rated = candidate.section.instructors
+			.map((name) => ratings.get(name))
+			.filter((r): r is number => r !== undefined);
+		if (rated.length > 0) {
+			const sum = rated.reduce((a, b) => a + b, 0);
+			sectionRatings.push(sum / rated.length);
+		}
+	}
+	const avgInstructorRating =
+		sectionRatings.length === 0
+			? null
+			: sectionRatings.reduce((a, b) => a + b, 0) / sectionRatings.length;
+
+	const starts = slots.map((s) => s.start);
+	const ends = slots.map((s) => s.end);
+
+	return {
+		avgInstructorRating,
+		ratedSectionCount: sectionRatings.length,
+		sectionCount: combo.length,
+		minCredits: sumMinCredits(combo),
+		maxCredits: combo.reduce((total, c) => total + (c.course.maxCredits ?? c.course.minCredits), 0),
+		daysWithClasses: slotsByDay.size,
+		totalGapMinutes,
+		earliestStartMinutes: starts.length ? Math.min(...starts) : null,
+		latestEndMinutes: ends.length ? Math.max(...ends) : null,
+		minOpenSeats: Math.min(...combo.map((c) => c.section.openSeats))
+	};
+}
+
+/** Remove pin notices that are exact duplicates. */
+function dedupePinNotices(notices: PinNotice[]): PinNotice[] {
+	const seen = new Set<string>();
+	const result: PinNotice[] = [];
+	for (const notice of notices) {
+		const key = JSON.stringify(notice);
+		if (!seen.has(key)) {
+			seen.add(key);
+			result.push(notice);
+		}
+	}
+	return result;
+}
+
+/**
+ * Generate every conflict-free schedule for the given course requests under
+ * the given hard constraints.
+ *
+ * @param requests The courses to schedule, with required/optional and pins.
+ * @param constraints Hard constraints every schedule must satisfy.
+ * @param instructorRatings Instructor name -> average rating, for metrics.
+ * @param maxResults Cap on returned schedules.
+ */
+export function generate(
+	requests: CourseRequest[],
+	constraints: HardConstraints,
+	instructorRatings: Map<string, number> = new Map(),
+	maxResults: number = DEFAULT_MAX_RESULTS
+): GenerationResult {
+	const pinNotices: PinNotice[] = [];
+
+	// STAGE 1 — Pre-filter. Drop sections that violate per-section
+	// constraints. Pinned courses skip the filter (the pin wins) but report
+	// what each pinned section overrode.
+	const perCourse = requests.map((request) => {
+		const candidates: Candidate[] = pinnedSections(request).map((section) => ({
+			course: request.course,
+			section,
+			slots: minuteSlots(section)
+		}));
+		let kept: Candidate[];
+		if (request.pin.kind === 'none') {
+			kept = candidates.filter((c) => candidatePasses(c, constraints));
+		} else {
+			for (const candidate of candidates) {
+				const overridden = overriddenFilters(candidate, constraints);
+				if (overridden.length > 0) {
+					pinNotices.push({
+						courseCode: request.course.courseCode,
+						sectionCode: candidate.section.sectionCode,
+						overriddenFilters: overridden
+					});
+				}
+			}
+			kept = candidates;
+		}
+		return { request, candidates: kept };
+	});
+
+	// STAGE 2 — Impossibility check. Only required courses with zero valid
+	// sections make generation impossible; optional ones are simply dropped.
+	const coursesWithoutSections = perCourse
+		.filter((p) => p.request.required && p.candidates.length === 0)
+		.map((p) => p.request.course.courseCode);
+	if (requests.length === 0 || coursesWithoutSections.length > 0) {
+		return {
+			schedules: [],
+			truncated: false,
+			coursesWithNoValidSections: coursesWithoutSections,
+			pinNotices: dedupePinNotices(pinNotices)
+		};
+	}
+
+	// STAGE 3 — Fail-first ordering. Courses with the fewest candidates go
+	// first so dead branches are pruned as early as possible.
+	const ordered: CourseCandidates[] = perCourse
+		.filter((p) => p.candidates.length > 0)
+		.map((p) => ({
+			candidates: p.candidates,
+			optional: !p.request.required
+		}))
+		.sort((a, b) => a.candidates.length - b.candidates.length);
+
+	const found: Candidate[][] = [];
+	const chosen: Candidate[] = [];
+	const placedSlots: MinuteSlot[] = [];
+	let nodes = 0;
+	let truncated = false;
+	const minCredits = constraints.minCredits;
+
+	// STAGE 4 — Depth-first search with backtracking.
+	function dfs(courseIndex: number): void {
+		if (truncated) {
+			return;
+		}
+		if (courseIndex === ordered.length) {
+			// Leaf: skip the empty schedule and any below the credit floor.
+			const creditsOk = minCredits === null || sumMinCredits(chosen) >= minCredits;
+			if (chosen.length > 0 && creditsOk) {
+				found.push([...chosen]);
+				if (found.length >= maxResults) {
+					truncated = true;
+				}
+			}
+			return;
+		}
+		const courseCandidates = ordered[courseIndex];
+		for (const candidate of courseCandidates.candidates) {
+			if (++nodes > MAX_NODES) {
+				truncated = true;
+				return;
+			}
+			const conflicts = candidate.slots.some((slot) =>
+				placedSlots.some((placed) => slotsConflict(slot, placed, constraints.minGapMinutes))
+			);
+			if (conflicts) {
+				continue;
+			}
+			chosen.push(candidate);
+			for (const slot of candidate.slots) {
+				placedSlots.push(slot);
+			}
+			dfs(courseIndex + 1);
+			chosen.pop();
+			for (let k = 0; k < candidate.slots.length; k++) {
+				placedSlots.pop();
+			}
+			if (truncated) {
+				return;
+			}
+		}
+		// Optional courses can be left out. Explore the skip branch AFTER the
+		// include branches so fuller schedules are found (and kept on
+		// truncation) first.
+		if (courseCandidates.optional) {
+			dfs(courseIndex + 1);
+		}
+	}
+	dfs(0);
+
+	// STAGE 5 — Present selections in the caller's course order.
+	const orderIndex = new Map<string, number>();
+	requests.forEach((request, i) => {
+		orderIndex.set(request.course.courseCode, i);
+	});
+	const schedules: GeneratedSchedule[] = found.map((combo) => {
+		const selections = [...combo]
+			.sort(
+				(a, b) =>
+					(orderIndex.get(a.course.courseCode) ?? 0) - (orderIndex.get(b.course.courseCode) ?? 0)
+			)
+			.map((candidate, i) => toScheduleSelection(candidate, i));
+		return {
+			selections,
+			metrics: computeMetrics(combo, instructorRatings)
+		};
+	});
+
+	return {
+		schedules,
+		truncated,
+		coursesWithNoValidSections: [],
+		pinNotices: dedupePinNotices(pinNotices)
+	};
+}
+
+/**
+ * Convenience overload: generate from a plain list of courses, treating every
+ * course as required with no pin.
+ */
+export function generateFromCourses(
+	courses: Course[],
+	constraints: HardConstraints,
+	instructorRatings: Map<string, number> = new Map(),
+	maxResults: number = DEFAULT_MAX_RESULTS
+): GenerationResult {
+	const requests: CourseRequest[] = courses.map((course) => ({
+		course,
+		required: true,
+		pin: { kind: 'none' }
+	}));
+	return generate(requests, constraints, instructorRatings, maxResults);
+}

--- a/site/src/lib/schedule-generator/ScheduleGenerator.ts
+++ b/site/src/lib/schedule-generator/ScheduleGenerator.ts
@@ -27,7 +27,7 @@ import type {
 } from './types';
 
 /** Default cap on the number of schedules returned. */
-export const DEFAULT_MAX_RESULTS = 200;
+export const DEFAULT_MAX_RESULTS = 1000;
 
 /** Hard cap on explored search nodes so degenerate inputs can't hang. */
 const MAX_NODES = 500_000;

--- a/site/src/lib/schedule-generator/ScheduleGenerator.ts
+++ b/site/src/lib/schedule-generator/ScheduleGenerator.ts
@@ -285,12 +285,16 @@ function dedupePinNotices(notices: PinNotice[]): PinNotice[] {
  * @param constraints Hard constraints every schedule must satisfy.
  * @param instructorRatings Instructor name -> average rating, for metrics.
  * @param maxResults Cap on returned schedules.
+ * @param maxNodes Hard cap on explored search nodes; defaults to MAX_NODES.
+ *   Pass a smaller value for lightweight probes (e.g. relaxation hints) to
+ *   bound their cost. The primary generation run should use the default.
  */
 export function generate(
 	requests: CourseRequest[],
 	constraints: HardConstraints,
 	instructorRatings: Map<string, number> = new Map(),
-	maxResults: number = DEFAULT_MAX_RESULTS
+	maxResults: number = DEFAULT_MAX_RESULTS,
+	maxNodes: number = MAX_NODES
 ): GenerationResult {
 	const pinNotices: PinNotice[] = [];
 
@@ -371,7 +375,7 @@ export function generate(
 		}
 		const courseCandidates = ordered[courseIndex];
 		for (const candidate of courseCandidates.candidates) {
-			if (++nodes > MAX_NODES) {
+			if (++nodes > maxNodes) {
 				truncated = true;
 				return;
 			}

--- a/site/src/lib/schedule-generator/ScheduleSorter.test.ts
+++ b/site/src/lib/schedule-generator/ScheduleSorter.test.ts
@@ -1,0 +1,94 @@
+/**
+ * This file is part of Jupiterp. For terms of use, please see the file
+ * called LICENSE at the top level of the Jupiterp source tree (online at
+ * https://github.com/atcupps/Jupiterp/LICENSE).
+ * Copyright (C) 2026 Andrew Cupps
+ *
+ * @fileoverview Unit tests for schedule ranking.
+ */
+
+import { describe, expect, test } from '@jest/globals';
+import { sortedByCriterion } from './ScheduleSorter';
+import type { GeneratedSchedule, ScheduleMetrics } from './types';
+
+/** Build a schedule with only the metrics fields a test cares about. */
+function withMetrics(metrics: Partial<ScheduleMetrics>): GeneratedSchedule {
+	return {
+		selections: [],
+		metrics: {
+			avgInstructorRating: null,
+			ratedSectionCount: 0,
+			sectionCount: 0,
+			minCredits: 0,
+			maxCredits: 0,
+			daysWithClasses: 0,
+			totalGapMinutes: 0,
+			earliestStartMinutes: null,
+			latestEndMinutes: null,
+			minOpenSeats: 0,
+			...metrics
+		}
+	};
+}
+
+describe('sortedByCriterion', () => {
+	test('most classes sorts by section count descending', () => {
+		const few = withMetrics({ sectionCount: 2 });
+		const many = withMetrics({ sectionCount: 5 });
+		const sorted = sortedByCriterion([few, many], 'mostClasses');
+		expect(sorted[0]).toBe(many);
+	});
+
+	test('best rating sorts descending with unrated last', () => {
+		const low = withMetrics({ avgInstructorRating: 3 });
+		const high = withMetrics({ avgInstructorRating: 4.5 });
+		const unrated = withMetrics({ avgInstructorRating: null });
+		const sorted = sortedByCriterion([low, unrated, high], 'bestRating');
+		expect(sorted).toEqual([high, low, unrated]);
+	});
+
+	test('most compact sorts by gap minutes ascending', () => {
+		const gappy = withMetrics({ totalGapMinutes: 200 });
+		const tight = withMetrics({ totalGapMinutes: 30 });
+		const sorted = sortedByCriterion([gappy, tight], 'mostCompact');
+		expect(sorted[0]).toBe(tight);
+	});
+
+	test('fewest days sorts by days with classes ascending', () => {
+		const five = withMetrics({ daysWithClasses: 5 });
+		const three = withMetrics({ daysWithClasses: 3 });
+		const sorted = sortedByCriterion([five, three], 'fewestDays');
+		expect(sorted[0]).toBe(three);
+	});
+
+	test('latest start puts untimed first', () => {
+		const early = withMetrics({ earliestStartMinutes: 8 * 60 });
+		const late = withMetrics({ earliestStartMinutes: 13 * 60 });
+		const untimed = withMetrics({ earliestStartMinutes: null });
+		const sorted = sortedByCriterion([early, late, untimed], 'latestStart');
+		expect(sorted[0]).toBe(untimed);
+		expect(sorted[1]).toBe(late);
+	});
+
+	test('earliest end sorts by latest end ascending', () => {
+		const late = withMetrics({ latestEndMinutes: 18 * 60 });
+		const early = withMetrics({ latestEndMinutes: 14 * 60 });
+		const sorted = sortedByCriterion([late, early], 'earliestEnd');
+		expect(sorted[0]).toBe(early);
+	});
+
+	test('most credits sorts by max credits descending', () => {
+		const light = withMetrics({ maxCredits: 12 });
+		const heavy = withMetrics({ maxCredits: 17 });
+		const sorted = sortedByCriterion([light, heavy], 'mostCredits');
+		expect(sorted[0]).toBe(heavy);
+	});
+
+	test('does not mutate the input array', () => {
+		const a = withMetrics({ sectionCount: 1 });
+		const b = withMetrics({ sectionCount: 2 });
+		const input = [a, b];
+		sortedByCriterion(input, 'mostClasses');
+		expect(input).toEqual([a, b]);
+	});
+});

--- a/site/src/lib/schedule-generator/ScheduleSorter.ts
+++ b/site/src/lib/schedule-generator/ScheduleSorter.ts
@@ -1,0 +1,101 @@
+/**
+ * This file is part of Jupiterp. For terms of use, please see the file
+ * called LICENSE at the top level of the Jupiterp source tree (online at
+ * https://github.com/atcupps/Jupiterp/LICENSE).
+ * Copyright (C) 2026 Andrew Cupps
+ *
+ * @fileoverview Comparators for ranking generated schedules by a
+ * `SortCriterion`. Every criterion has explicit tie-breakers, and unrated
+ * schedules always sort below rated ones. Ported from the mobile app's
+ * `ScheduleSorter`.
+ */
+
+import type { GeneratedSchedule, SortCriterion } from './types';
+
+type Comparator = (a: GeneratedSchedule, b: GeneratedSchedule) => number;
+
+/** Unrated schedules map to -1 so they sort below any rated schedule. */
+function ratingOrUnrated(schedule: GeneratedSchedule): number {
+	return schedule.metrics.avgInstructorRating ?? -1;
+}
+
+/** Ascending comparator on a numeric selector. */
+function byAsc(selector: (s: GeneratedSchedule) => number): Comparator {
+	return (a, b) => selector(a) - selector(b);
+}
+
+/** Descending comparator on a numeric selector. */
+function byDesc(selector: (s: GeneratedSchedule) => number): Comparator {
+	return (a, b) => selector(b) - selector(a);
+}
+
+/** Compose comparators, applying each as a tie-breaker for the previous. */
+function chain(...comparators: Comparator[]): Comparator {
+	return (a, b) => {
+		for (const comparator of comparators) {
+			const result = comparator(a, b);
+			if (result !== 0) {
+				return result;
+			}
+		}
+		return 0;
+	};
+}
+
+/** Build the comparator for a given sort criterion. */
+function comparatorFor(criterion: SortCriterion): Comparator {
+	switch (criterion) {
+		case 'mostClasses':
+			return chain(
+				byDesc((s) => s.metrics.sectionCount),
+				byDesc(ratingOrUnrated),
+				byAsc((s) => s.metrics.totalGapMinutes)
+			);
+		case 'bestRating':
+			return chain(
+				byDesc(ratingOrUnrated),
+				byAsc((s) => s.metrics.totalGapMinutes),
+				byAsc((s) => s.metrics.daysWithClasses)
+			);
+		case 'mostCompact':
+			return chain(
+				byAsc((s) => s.metrics.totalGapMinutes),
+				byAsc((s) => s.metrics.daysWithClasses),
+				byDesc(ratingOrUnrated)
+			);
+		case 'fewestDays':
+			return chain(
+				byAsc((s) => s.metrics.daysWithClasses),
+				byAsc((s) => s.metrics.totalGapMinutes),
+				byDesc(ratingOrUnrated)
+			);
+		case 'latestStart':
+			// No timed meetings at all is the latest possible start.
+			return chain(
+				byDesc((s) => s.metrics.earliestStartMinutes ?? Number.MAX_SAFE_INTEGER),
+				byDesc(ratingOrUnrated)
+			);
+		case 'earliestEnd':
+			return chain(
+				byAsc((s) => s.metrics.latestEndMinutes ?? 0),
+				byDesc(ratingOrUnrated)
+			);
+		case 'mostCredits':
+			return chain(
+				byDesc((s) => s.metrics.maxCredits),
+				byDesc((s) => s.metrics.minCredits),
+				byDesc(ratingOrUnrated)
+			);
+	}
+}
+
+/**
+ * Return a new array of schedules sorted by the given criterion. The input
+ * array is not mutated.
+ */
+export function sortedByCriterion(
+	schedules: GeneratedSchedule[],
+	criterion: SortCriterion
+): GeneratedSchedule[] {
+	return [...schedules].sort(comparatorFor(criterion));
+}

--- a/site/src/lib/schedule-generator/WishlistActions.test.ts
+++ b/site/src/lib/schedule-generator/WishlistActions.test.ts
@@ -1,0 +1,88 @@
+/**
+ * This file is part of Jupiterp. For terms of use, please see the file
+ * called LICENSE at the top level of the Jupiterp source tree (online at
+ * https://github.com/atcupps/Jupiterp/LICENSE).
+ * Copyright (C) 2026 Andrew Cupps
+ *
+ * @fileoverview Unit tests for WishlistActions.ts
+ */
+
+import type { Course } from '@jupiterp/jupiterp';
+import { addRequirement, chosenCourseCodes, removeRequirement } from './WishlistActions';
+import { describe, expect, test } from '@jest/globals';
+
+/** Builds a minimal Course with the given code; other fields are unused here. */
+function course(courseCode: string): Course {
+	return {
+		courseCode,
+		name: `${courseCode} Course`,
+		minCredits: 3,
+		maxCredits: null,
+		genEds: null,
+		conditions: null,
+		description: null,
+		sections: null
+	};
+}
+
+describe('addRequirement', () => {
+	test('appends a new course as a required, unpinned requirement', () => {
+		const result = addRequirement([], course('CMSC131'));
+		expect(result).toHaveLength(1);
+		expect(result[0]).toEqual({
+			course: course('CMSC131'),
+			required: true,
+			pin: { kind: 'none' }
+		});
+	});
+
+	test('preserves existing requirements and appends at the end', () => {
+		const start = addRequirement([], course('CMSC131'));
+		const result = addRequirement(start, course('MATH140'));
+		expect(result.map((r) => r.course.courseCode)).toEqual(['CMSC131', 'MATH140']);
+	});
+
+	test('is a no-op when the course is already present', () => {
+		const start = addRequirement([], course('CMSC131'));
+		const result = addRequirement(start, course('CMSC131'));
+		expect(result).toBe(start);
+		expect(result).toHaveLength(1);
+	});
+
+	test('does not mutate the input array', () => {
+		const start = addRequirement([], course('CMSC131'));
+		addRequirement(start, course('MATH140'));
+		expect(start).toHaveLength(1);
+	});
+});
+
+describe('removeRequirement', () => {
+	test('removes the requirement matching the course code', () => {
+		const start = addRequirement(addRequirement([], course('CMSC131')), course('MATH140'));
+		const result = removeRequirement(start, 'CMSC131');
+		expect(result.map((r) => r.course.courseCode)).toEqual(['MATH140']);
+	});
+
+	test('leaves the wishlist unchanged when the code is absent', () => {
+		const start = addRequirement([], course('CMSC131'));
+		const result = removeRequirement(start, 'ENGL101');
+		expect(result.map((r) => r.course.courseCode)).toEqual(['CMSC131']);
+	});
+
+	test('does not mutate the input array', () => {
+		const start = addRequirement([], course('CMSC131'));
+		removeRequirement(start, 'CMSC131');
+		expect(start).toHaveLength(1);
+	});
+});
+
+describe('chosenCourseCodes', () => {
+	test('returns the set of course codes in the wishlist', () => {
+		const reqs = addRequirement(addRequirement([], course('CMSC131')), course('MATH140'));
+		expect(chosenCourseCodes(reqs)).toEqual(new Set(['CMSC131', 'MATH140']));
+	});
+
+	test('returns an empty set for an empty wishlist', () => {
+		expect(chosenCourseCodes([]).size).toBe(0);
+	});
+});

--- a/site/src/lib/schedule-generator/WishlistActions.ts
+++ b/site/src/lib/schedule-generator/WishlistActions.ts
@@ -1,0 +1,40 @@
+/**
+ * This file is part of Jupiterp. For terms of use, please see the file
+ * called LICENSE at the top level of the Jupiterp source tree (online at
+ * https://github.com/atcupps/Jupiterp/LICENSE).
+ * Copyright (C) 2026 Andrew Cupps
+ *
+ * @fileoverview Pure helpers for mutating the generator course wishlist. Kept
+ * free of Svelte stores and `$lib` imports (type-only) so the add/remove logic
+ * can be unit-tested directly; the store just wraps these in `.update(...)`.
+ */
+
+import type { Course } from '@jupiterp/jupiterp';
+import type { GeneratorRequirement } from '../../stores/GeneratorStores';
+
+/** The set of course codes already present in the wishlist. */
+export function chosenCourseCodes(reqs: GeneratorRequirement[]): Set<string> {
+	return new Set(reqs.map((r) => r.course.courseCode));
+}
+
+/**
+ * Appends `course` to the wishlist as a required, unpinned requirement. Returns
+ * the array unchanged if the course is already present (matched by code).
+ */
+export function addRequirement(
+	reqs: GeneratorRequirement[],
+	course: Course
+): GeneratorRequirement[] {
+	if (reqs.some((r) => r.course.courseCode === course.courseCode)) {
+		return reqs;
+	}
+	return [...reqs, { course, required: true, pin: { kind: 'none' } }];
+}
+
+/** Removes the requirement matching `courseCode`, leaving others in order. */
+export function removeRequirement(
+	reqs: GeneratorRequirement[],
+	courseCode: string
+): GeneratorRequirement[] {
+	return reqs.filter((r) => r.course.courseCode !== courseCode);
+}

--- a/site/src/lib/schedule-generator/types.ts
+++ b/site/src/lib/schedule-generator/types.ts
@@ -1,0 +1,165 @@
+/**
+ * This file is part of Jupiterp. For terms of use, please see the file
+ * called LICENSE at the top level of the Jupiterp source tree (online at
+ * https://github.com/atcupps/Jupiterp/LICENSE).
+ * Copyright (C) 2026 Andrew Cupps
+ *
+ * @fileoverview Input and output types for the automatic schedule generator.
+ * These are the web analogs of the mobile app's scheduler models. All times
+ * are in minutes since midnight (e.g. 9:30 AM = 570) so that conflict and gap
+ * arithmetic is exact integer math.
+ */
+
+import type { Course } from '@jupiterp/jupiterp';
+import type { ScheduleSelection } from '../../types';
+
+/**
+ * The seven distinct days of the week a class can meet on. Unlike the
+ * planner's `Day` enum (which collapses Saturday and Sunday into a single
+ * `Other` bucket for rendering), the generator keeps all seven days distinct
+ * so that, for example, a Saturday class never conflicts with a Sunday one.
+ */
+export type EngineDay = 'M' | 'Tu' | 'W' | 'Th' | 'F' | 'Sa' | 'Su';
+
+/**
+ * Hard constraints a generated schedule must satisfy. Times are minutes since
+ * midnight (9:30 AM = 570).
+ */
+export interface HardConstraints {
+	earliestStartMinutes: number | null;
+	latestEndMinutes: number | null;
+	daysOff: Set<EngineDay>;
+	onlyOpenSeats: boolean;
+	minGapMinutes: number;
+	minCredits: number | null;
+}
+
+/**
+ * @returns A `HardConstraints` with sensible defaults (only open sections,
+ * no time window, no days off, no gap or credit floor).
+ */
+export function defaultConstraints(): HardConstraints {
+	return {
+		earliestStartMinutes: null,
+		latestEndMinutes: null,
+		daysOff: new Set<EngineDay>(),
+		onlyOpenSeats: true,
+		minGapMinutes: 0,
+		minCredits: null
+	};
+}
+
+/**
+ * A way to narrow a course to a single section or a single professor,
+ * overriding the per-section filters.
+ */
+export type SectionPin =
+	| { kind: 'none' }
+	| { kind: 'bySection'; sectionCode: string }
+	| { kind: 'byInstructor'; name: string };
+
+/**
+ * One course to schedule, plus how strictly to place it. Required courses
+ * appear in every schedule; optional ones are included only when they fit.
+ */
+export interface CourseRequest {
+	course: Course;
+	required: boolean;
+	pin: SectionPin;
+}
+
+/** A per-section filter that a pinned section was kept despite violating. */
+export type OverriddenFilter = 'earliestStart' | 'latestEnd' | 'dayOff' | 'openSeats';
+
+/** Raised when a pinned section was kept despite violating active filters. */
+export interface PinNotice {
+	courseCode: string;
+	sectionCode: string;
+	overriddenFilters: OverriddenFilter[];
+}
+
+/**
+ * Computed once per schedule so re-sorting never regenerates. Time metrics
+ * are null when all meetings are async/TBA.
+ */
+export interface ScheduleMetrics {
+	avgInstructorRating: number | null;
+	ratedSectionCount: number;
+	sectionCount: number;
+	minCredits: number;
+	maxCredits: number;
+	daysWithClasses: number;
+	totalGapMinutes: number;
+	earliestStartMinutes: number | null;
+	latestEndMinutes: number | null;
+	minOpenSeats: number;
+}
+
+/** A generated schedule: planner selections plus precomputed metrics. */
+export interface GeneratedSchedule {
+	selections: ScheduleSelection[];
+	metrics: ScheduleMetrics;
+}
+
+/** The full result of a generation run. */
+export interface GenerationResult {
+	/** Found schedules (already capped at `maxResults`). */
+	schedules: GeneratedSchedule[];
+
+	/** True if a result/node cap was hit; more schedules may exist. */
+	truncated: boolean;
+
+	/** Required courses that made generation impossible. */
+	coursesWithNoValidSections: string[];
+
+	/** Pins forced in despite violating active filters. */
+	pinNotices: PinNotice[];
+}
+
+/** A single constraint loosened from a `HardConstraints`. */
+export type RelaxationKind =
+	| 'earliestStart'
+	| 'latestEnd'
+	| 'dayOff'
+	| 'openSeats'
+	| 'minGap'
+	| 'minCredits';
+
+/** A constraint set differing from the original by one loosened restriction. */
+export interface Relaxation {
+	kind: RelaxationKind;
+	day: EngineDay | null;
+	constraints: HardConstraints;
+}
+
+/** The criteria by which generated schedules can be ranked. */
+export type SortCriterion =
+	| 'mostClasses'
+	| 'bestRating'
+	| 'mostCompact'
+	| 'fewestDays'
+	| 'latestStart'
+	| 'earliestEnd'
+	| 'mostCredits';
+
+/** Human-readable labels for each `SortCriterion`. */
+export const SORT_CRITERION_LABELS: Record<SortCriterion, string> = {
+	mostClasses: 'Most classes',
+	bestRating: 'Top rated',
+	mostCompact: 'Fewest gaps',
+	fewestDays: 'Fewest days',
+	latestStart: 'Latest start',
+	earliestEnd: 'Earliest finish',
+	mostCredits: 'Most credits'
+};
+
+/** The ordered list of sort criteria, for rendering a sort selector. */
+export const SORT_CRITERIA: SortCriterion[] = [
+	'bestRating',
+	'mostClasses',
+	'mostCompact',
+	'fewestDays',
+	'latestStart',
+	'earliestEnd',
+	'mostCredits'
+];

--- a/site/src/routes/+page.svelte
+++ b/site/src/routes/+page.svelte
@@ -14,20 +14,14 @@ Copyright (C) 2026 Andrew Cupps
 		resolveSelections,
 		resolveStoredSchedules
 	} from '../lib/course-planner/CourseLoad';
-	import { getProfsLookup } from '$lib/course-planner/CourseSearch';
+	import { loadInstructorLookup } from '$lib/course-planner/CourseSearch';
 	import { handlePlannerShortcutKeydown } from '../lib/course-planner/PlannerShortcuts';
 	import {
-		ProfsLookupStore,
 		CurrentScheduleStore,
 		NonselectedScheduleStore,
 		DepartmentsStore
 	} from '../stores/CoursePlannerStores';
 	import { client } from '$lib/client';
-	import {
-		type Instructor,
-		type InstructorsConfig,
-		type InstructorsResponse
-	} from '@jupiterp/jupiterp';
 	import type { ScheduleBlock, StoredSchedule } from '../types';
 	import IsDesktop from '../components/course-planner/IsDesktop.svelte';
 	import { PlannerState } from '../stores/CoursePlannerStores';
@@ -42,42 +36,6 @@ Copyright (C) 2026 Andrew Cupps
 			chainScrollParent: plannerContainer
 		})
 	);
-
-	// Function to retrieve professor data; called in `onMount`.
-	async function fetchProfessorData() {
-		try {
-			let limit = 500;
-			let offset = 0;
-			let allInstructors: Instructor[] = [];
-			let config: InstructorsConfig = {
-				limit: limit,
-				offset: offset
-			};
-			let complete = false;
-			while (!complete) {
-				const response: InstructorsResponse = await client.activeInstructors(config);
-				if (response.ok() && response.data != null) {
-					allInstructors = [...allInstructors, ...response.data];
-					if (response.data.length < limit) {
-						complete = true;
-						break;
-					}
-					offset += limit;
-					config.offset = offset;
-				} else {
-					// format-check exempt 1
-					throw new Error(
-						`Failed to fetch data: ${response.statusCode} ${response.statusMessage} ${response.errorBody}`
-					);
-				}
-			}
-
-			// Update the ProfsLookupStore with the fetched data
-			ProfsLookupStore.set(getProfsLookup(allInstructors));
-		} catch (error) {
-			console.error('Error fetching professor data:', error);
-		}
-	}
 
 	// Function to get list of department codes as an array of strings
 	// and set the DepartmentsStore.
@@ -125,7 +83,7 @@ Copyright (C) 2026 Andrew Cupps
 
 	onMount(() => {
 		// Fetch instructor data from API
-		fetchProfessorData();
+		loadInstructorLookup();
 
 		// Fetch department codes from API
 		fetchDeptCodes();

--- a/site/src/routes/generate/+page.svelte
+++ b/site/src/routes/generate/+page.svelte
@@ -1,0 +1,52 @@
+<!--
+This file is part of Jupiterp. For terms of use, please see the file
+called LICENSE at the top level of the Jupiterp source tree (online at
+https://github.com/atcupps/Jupiterp/LICENSE).
+Copyright (C) 2026 Andrew Cupps
+-->
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import GeneratorView from '../../components/schedule-generator/GeneratorView.svelte';
+	import { loadInstructorLookup } from '$lib/course-planner/CourseSearch';
+	import { client } from '$lib/client';
+	import { DepartmentsStore } from '../../stores/CoursePlannerStores';
+
+	// Departments are needed so the course search can resolve department codes.
+	async function fetchDeptCodes() {
+		const res = await client.deptList();
+		if (res.ok() && res.data != null) {
+			DepartmentsStore.set(res.data);
+		} else {
+			console.error('Error fetching department codes:', res.errorBody);
+		}
+	}
+
+	onMount(() => {
+		loadInstructorLookup();
+		fetchDeptCodes();
+	});
+</script>
+
+<svelte:head>
+	<title>Schedule Generator | Jupiterp</title>
+	<meta
+		name="description"
+		content="Automatically generate conflict-free UMD course schedules
+			from your desired courses and constraints."
+	/>
+</svelte:head>
+
+<div
+	class="custom-scrollbar fixed bottom-0 top-12 w-full overflow-y-auto
+		px-4 py-3 text-textLight dark:text-textDark"
+>
+	<div class="mb-3">
+		<h1 class="text-2xl font-bold">Schedule Generator</h1>
+		<p class="text-sm opacity-70">
+			Pick your courses, set any constraints, and Jupiterp will find every conflict-free schedule —
+			ranked your way.
+		</p>
+	</div>
+
+	<GeneratorView />
+</div>

--- a/site/src/routes/generate/+page.svelte
+++ b/site/src/routes/generate/+page.svelte
@@ -40,13 +40,5 @@ Copyright (C) 2026 Andrew Cupps
 	class="custom-scrollbar fixed bottom-0 top-12 w-full overflow-y-auto
 		px-4 py-3 text-textLight dark:text-textDark"
 >
-	<div class="mb-3">
-		<h1 class="text-2xl font-bold">Schedule Generator</h1>
-		<p class="text-sm opacity-70">
-			Pick your courses, set any constraints, and Jupiterp will find every conflict-free schedule —
-			ranked your way.
-		</p>
-	</div>
-
 	<GeneratorView />
 </div>

--- a/site/src/stores/GeneratorStores.ts
+++ b/site/src/stores/GeneratorStores.ts
@@ -1,0 +1,73 @@
+/**
+ * This file is part of Jupiterp. For terms of use, please see the file
+ * called LICENSE at the top level of the Jupiterp source tree (online at
+ * https://github.com/atcupps/Jupiterp/LICENSE).
+ * Copyright (C) 2026 Andrew Cupps
+ *
+ * @fileoverview Svelte stores backing the schedule generator page: the course
+ * wishlist, the hard constraints, the chosen sort criterion, and the current
+ * generation state.
+ */
+
+import type { Course } from '@jupiterp/jupiterp';
+import { writable, type Writable } from 'svelte/store';
+import { defaultConstraints } from '$lib/schedule-generator/types';
+import type {
+	GeneratedSchedule,
+	HardConstraints,
+	PinNotice,
+	Relaxation,
+	SectionPin,
+	SortCriterion
+} from '$lib/schedule-generator/types';
+
+/**
+ * One course the user wants the generator to schedule around, plus whether it
+ * is required and any pin narrowing it to a section or professor.
+ */
+export interface GeneratorRequirement {
+	course: Course;
+	required: boolean;
+	pin: SectionPin;
+}
+
+/**
+ * A single constraint relaxation paired with how many schedules it would
+ * unlock, used to explain zero-result generations.
+ */
+export interface RelaxationHint {
+	relaxation: Relaxation;
+	scheduleCount: number;
+	truncated: boolean;
+}
+
+/** The outcome of a generation run, used to drive the results UI. */
+export type GenerationState =
+	| { kind: 'idle' }
+	| { kind: 'loading' }
+	| {
+			kind: 'done';
+			schedules: GeneratedSchedule[];
+			truncated: boolean;
+			pinNotices: PinNotice[];
+	  }
+	| {
+			kind: 'noSchedules';
+			hints: RelaxationHint[];
+			coursesWithNoValidSections: string[];
+	  }
+	| { kind: 'failed'; message: string };
+
+/** The course wishlist the generator builds schedules from. */
+export const GeneratorRequirementsStore: Writable<GeneratorRequirement[]> = writable([]);
+
+/** The hard constraints every generated schedule must satisfy. */
+export const GeneratorConstraintsStore: Writable<HardConstraints> = writable(defaultConstraints());
+
+/** The criterion by which results are currently ranked. */
+export const GeneratorSortStore: Writable<SortCriterion> = writable('bestRating');
+
+/** The current generation state. */
+export const GenerationStateStore: Writable<GenerationState> = writable({
+	kind: 'idle'
+});


### PR DESCRIPTION
**Schedule Generator -** Issue #931

The algorithm was ported from the [mobile version of Jupiterp](https://github.com/Chase-Fournier/JupiterpMobile)

Front End:
- A new page was added, "Schedule Generator"
- The search and filters were reused from the main page to add schedules to the list to be generated
- Constraints are listed under it for filtering the generator
- Once generated, up to 1000 schedules are generated and they are sortable and viewed in smaller cards

Generator
- Finds all the sections needed to search though based on constraints
- Checks impossibilities in relation too other courses
- sorted by candidate count
- DFS, checking for conflicts, prioritizes adding more courses
- Computes metrics for each course for sorting
- If there is no schedules matching criteria, offer ways to relax the contraints

Passes EsLint & all new files pass the format check