### PR TITLE
Sharable links

### DIFF
--- a/site/src/components/course-planner/course-search/CourseSearchBox.svelte
+++ b/site/src/components/course-planner/course-search/CourseSearchBox.svelte
@@ -43,7 +43,8 @@ Copyright (C) 2026 Andrew Cupps
 	export let onBlur: (event: FocusEvent) => void = () => {};
 	/** Styling for the suggestion dropdown container. */
 	export let dropdownClass =
-		'mt-2 rounded-lg border border-outlineLight bg-bgLight shadow-lg ' +
+		'custom-scrollbar mt-2 max-h-72 overflow-y-auto rounded-lg border ' +
+		'border-outlineLight bg-bgLight shadow-lg ' +
 		'dark:border-outlineDark dark:bg-bgDark';
 
 	let searchResults: Course[] = [];
@@ -169,9 +170,9 @@ Copyright (C) 2026 Andrew Cupps
 			{#each profSuggestions as profName, index}
 				<button
 					type="button"
-					class="flex w-full items-center px-3 py-1 text-left text-sm
+					class="flex w-full items-center px-3 py-1 text-left text-base
 						transition-colors hover:bg-outlineLight hover:bg-opacity-20
-						dark:hover:bg-outlineDark dark:hover:bg-opacity-30"
+						lg:text-sm dark:hover:bg-outlineDark dark:hover:bg-opacity-30"
 					class:bg-outlineLight={highlightedProfIndex === index}
 					class:bg-opacity-20={highlightedProfIndex === index}
 					on:mouseenter={() => (highlightedProfIndex = index)}
@@ -187,9 +188,9 @@ Copyright (C) 2026 Andrew Cupps
 			{#each deptSuggestions as deptOption, index}
 				<button
 					type="button"
-					class="flex w-full items-end px-3 py-1 text-left text-sm
+					class="flex w-full items-end px-3 py-1 text-left text-base
 						transition-colors hover:bg-outlineLight hover:bg-opacity-20
-						dark:hover:bg-outlineDark dark:hover:bg-opacity-30"
+						lg:text-sm dark:hover:bg-outlineDark dark:hover:bg-opacity-30"
 					class:bg-outlineLight={highlightedDeptIndex === index}
 					class:bg-opacity-20={highlightedDeptIndex === index}
 					on:mouseenter={() => (highlightedDeptIndex = index)}

--- a/site/src/components/course-planner/course-search/ScheduleOptionsDropdown.svelte
+++ b/site/src/components/course-planner/course-search/ScheduleOptionsDropdown.svelte
@@ -26,6 +26,7 @@ Copyright (C) 2026 Andrew Cupps
 
 	let dropdownOpen = false;
 	let linkCopied = false;
+	let linkError = false;
 
 	let currentScheduleName: string;
 	let currentScheduleSelections: ScheduleBlock[];
@@ -88,6 +89,38 @@ Copyright (C) 2026 Andrew Cupps
 		AddCustomEventStore.set(true);
 	}
 
+	/**
+	 * Copy `text` to the clipboard, returning whether it succeeded. Prefers the
+	 * async Clipboard API (HTTPS / modern browsers) and falls back to a hidden
+	 * textarea + `execCommand('copy')` for insecure contexts and older mobile
+	 * browsers where `navigator.clipboard` is unavailable.
+	 */
+	async function copyToClipboard(text: string): Promise<boolean> {
+		if (typeof navigator !== 'undefined' && navigator.clipboard) {
+			try {
+				await navigator.clipboard.writeText(text);
+				return true;
+			} catch {
+				// Fall through to the legacy path.
+			}
+		}
+
+		try {
+			const textarea = document.createElement('textarea');
+			textarea.value = text;
+			textarea.setAttribute('readonly', '');
+			textarea.style.position = 'fixed';
+			textarea.style.opacity = '0';
+			document.body.appendChild(textarea);
+			textarea.select();
+			const ok = document.execCommand('copy');
+			document.body.removeChild(textarea);
+			return ok;
+		} catch {
+			return false;
+		}
+	}
+
 	async function copyShareLink() {
 		const token = encodeSchedule(currentScheduleSelections);
 		if (!token) {
@@ -96,15 +129,21 @@ Copyright (C) 2026 Andrew Cupps
 		}
 
 		const url = `${window.location.origin}${base}/?${SHARE_PARAM}=${token}`;
-		try {
-			await navigator.clipboard.writeText(url);
+		const copied = await copyToClipboard(url);
+		if (copied) {
+			linkError = false;
 			linkCopied = true;
 			setTimeout(() => {
 				linkCopied = false;
 				dropdownOpen = false;
 			}, 1200);
-		} catch (e) {
-			console.error('Failed to copy share link:', e);
+		} else {
+			linkCopied = false;
+			linkError = true;
+			console.error('Failed to copy share link to clipboard.');
+			setTimeout(() => {
+				linkError = false;
+			}, 1800);
 		}
 	}
 </script>
@@ -151,6 +190,8 @@ Copyright (C) 2026 Andrew Cupps
 	>
 		{#if linkCopied}
 			<ClipboardCheckOutline class="z-50 mr-1 h-3 w-3" /> Copied!
+		{:else if linkError}
+			<LinkOutline class="z-50 mr-1 h-3 w-3" /> Copy failed
 		{:else}
 			<LinkOutline class="z-50 mr-1 h-3 w-3" /> Copy Link
 		{/if}

--- a/site/src/components/course-planner/course-search/ScheduleOptionsDropdown.svelte
+++ b/site/src/components/course-planner/course-search/ScheduleOptionsDropdown.svelte
@@ -148,10 +148,7 @@ Copyright (C) 2026 Andrew Cupps
 	}
 </script>
 
-<button
-	class="rounded-md hover:bg-hoverLight dark:hover:bg-hoverDark"
-	title="Schedule options"
->
+<button class="rounded-md hover:bg-hoverLight dark:hover:bg-hoverDark" title="Schedule options">
 	<DotsVerticalOutline class="h-5 w-5" />
 </button>
 

--- a/site/src/components/course-planner/course-search/ScheduleOptionsDropdown.svelte
+++ b/site/src/components/course-planner/course-search/ScheduleOptionsDropdown.svelte
@@ -149,7 +149,7 @@ Copyright (C) 2026 Andrew Cupps
 </script>
 
 <button
-	class="rounded-md px-0.5 hover:bg-hoverLight dark:hover:bg-hoverDark"
+	class="rounded-md hover:bg-hoverLight dark:hover:bg-hoverDark"
 	title="Schedule options"
 >
 	<DotsVerticalOutline class="h-5 w-5" />

--- a/site/src/components/course-planner/course-search/ScheduleOptionsDropdown.svelte
+++ b/site/src/components/course-planner/course-search/ScheduleOptionsDropdown.svelte
@@ -10,7 +10,9 @@ Copyright (C) 2026 Andrew Cupps
 		DotsVerticalOutline,
 		TrashBinOutline,
 		FileCopyOutline,
-		PlusOutline
+		PlusOutline,
+		LinkOutline,
+		ClipboardCheckOutline
 	} from 'flowbite-svelte-icons';
 	import {
 		AddCustomEventStore,
@@ -18,9 +20,12 @@ Copyright (C) 2026 Andrew Cupps
 		NonselectedScheduleStore
 	} from '../../../stores/CoursePlannerStores';
 	import { uniqueScheduleName } from '$lib/course-planner/ScheduleSelector';
+	import { encodeSchedule, SHARE_PARAM } from '$lib/course-planner/ShareLink';
+	import { base } from '$app/paths';
 	import type { ScheduleBlock, StoredSchedule } from '../../../types';
 
 	let dropdownOpen = false;
+	let linkCopied = false;
 
 	let currentScheduleName: string;
 	let currentScheduleSelections: ScheduleBlock[];
@@ -82,6 +87,26 @@ Copyright (C) 2026 Andrew Cupps
 		dropdownOpen = false;
 		AddCustomEventStore.set(true);
 	}
+
+	async function copyShareLink() {
+		const token = encodeSchedule(currentScheduleSelections);
+		if (!token) {
+			// No course sections to share.
+			return;
+		}
+
+		const url = `${window.location.origin}${base}/?${SHARE_PARAM}=${token}`;
+		try {
+			await navigator.clipboard.writeText(url);
+			linkCopied = true;
+			setTimeout(() => {
+				linkCopied = false;
+				dropdownOpen = false;
+			}, 1200);
+		} catch (e) {
+			console.error('Failed to copy share link:', e);
+		}
+	}
 </script>
 
 <button
@@ -118,10 +143,16 @@ Copyright (C) 2026 Andrew Cupps
 		<FileCopyOutline class="z-50 mr-1 h-3 w-3" /> Duplicate
 	</DropdownItem>
 
-	<!-- TODO(@atcupps): Add share schedule feature -->
-	<!-- <DropdownItem class="hover:bg-hoverLight dark:hover:bg-hoverDark px-2
-                        flex justify-start items-center"
-                    on:click={() => (dropdownOpen = false)}>
-        <ForwardOutline class="w-3 h-3 mr-1" /> Share
-    </DropdownItem> -->
+	<DropdownItem
+		class="flex items-center justify-start
+                            px-2 hover:bg-hoverLight dark:hover:bg-hoverDark"
+		title="Copy a shareable link to this schedule"
+		on:click={copyShareLink}
+	>
+		{#if linkCopied}
+			<ClipboardCheckOutline class="z-50 mr-1 h-3 w-3" /> Copied!
+		{:else}
+			<LinkOutline class="z-50 mr-1 h-3 w-3" /> Copy Link
+		{/if}
+	</DropdownItem>
 </Dropdown>

--- a/site/src/components/course-planner/course-search/ScheduleOptionsDropdown.svelte
+++ b/site/src/components/course-planner/course-search/ScheduleOptionsDropdown.svelte
@@ -10,9 +10,7 @@ Copyright (C) 2026 Andrew Cupps
 		DotsVerticalOutline,
 		TrashBinOutline,
 		FileCopyOutline,
-		PlusOutline,
-		LinkOutline,
-		ClipboardCheckOutline
+		PlusOutline
 	} from 'flowbite-svelte-icons';
 	import {
 		AddCustomEventStore,
@@ -20,13 +18,9 @@ Copyright (C) 2026 Andrew Cupps
 		NonselectedScheduleStore
 	} from '../../../stores/CoursePlannerStores';
 	import { uniqueScheduleName } from '$lib/course-planner/ScheduleSelector';
-	import { encodeSchedule, SHARE_PARAM } from '$lib/course-planner/ShareLink';
-	import { base } from '$app/paths';
 	import type { ScheduleBlock, StoredSchedule } from '../../../types';
 
 	let dropdownOpen = false;
-	let linkCopied = false;
-	let linkError = false;
 
 	let currentScheduleName: string;
 	let currentScheduleSelections: ScheduleBlock[];
@@ -88,64 +82,6 @@ Copyright (C) 2026 Andrew Cupps
 		dropdownOpen = false;
 		AddCustomEventStore.set(true);
 	}
-
-	/**
-	 * Copy `text` to the clipboard, returning whether it succeeded. Prefers the
-	 * async Clipboard API (HTTPS / modern browsers) and falls back to a hidden
-	 * textarea + `execCommand('copy')` for insecure contexts and older mobile
-	 * browsers where `navigator.clipboard` is unavailable.
-	 */
-	async function copyToClipboard(text: string): Promise<boolean> {
-		if (typeof navigator !== 'undefined' && navigator.clipboard) {
-			try {
-				await navigator.clipboard.writeText(text);
-				return true;
-			} catch {
-				// Fall through to the legacy path.
-			}
-		}
-
-		try {
-			const textarea = document.createElement('textarea');
-			textarea.value = text;
-			textarea.setAttribute('readonly', '');
-			textarea.style.position = 'fixed';
-			textarea.style.opacity = '0';
-			document.body.appendChild(textarea);
-			textarea.select();
-			const ok = document.execCommand('copy');
-			document.body.removeChild(textarea);
-			return ok;
-		} catch {
-			return false;
-		}
-	}
-
-	async function copyShareLink() {
-		const token = encodeSchedule(currentScheduleSelections);
-		if (!token) {
-			// No course sections to share.
-			return;
-		}
-
-		const url = `${window.location.origin}${base}/?${SHARE_PARAM}=${token}`;
-		const copied = await copyToClipboard(url);
-		if (copied) {
-			linkError = false;
-			linkCopied = true;
-			setTimeout(() => {
-				linkCopied = false;
-				dropdownOpen = false;
-			}, 1200);
-		} else {
-			linkCopied = false;
-			linkError = true;
-			console.error('Failed to copy share link to clipboard.');
-			setTimeout(() => {
-				linkError = false;
-			}, 1800);
-		}
-	}
 </script>
 
 <button class="rounded-md hover:bg-hoverLight dark:hover:bg-hoverDark" title="Schedule options">
@@ -177,20 +113,5 @@ Copyright (C) 2026 Andrew Cupps
 		on:click={duplicateSchedule}
 	>
 		<FileCopyOutline class="z-50 mr-1 h-3 w-3" /> Duplicate
-	</DropdownItem>
-
-	<DropdownItem
-		class="flex items-center justify-start
-                            px-2 hover:bg-hoverLight dark:hover:bg-hoverDark"
-		title="Copy a shareable link to this schedule"
-		on:click={copyShareLink}
-	>
-		{#if linkCopied}
-			<ClipboardCheckOutline class="z-50 mr-1 h-3 w-3" /> Copied!
-		{:else if linkError}
-			<LinkOutline class="z-50 mr-1 h-3 w-3" /> Copy failed
-		{:else}
-			<LinkOutline class="z-50 mr-1 h-3 w-3" /> Copy Link
-		{/if}
 	</DropdownItem>
 </Dropdown>

--- a/site/src/components/course-planner/course-search/ScheduleSelector.svelte
+++ b/site/src/components/course-planner/course-search/ScheduleSelector.svelte
@@ -151,7 +151,7 @@ Copyright (C) 2026 Andrew Cupps
 		<ScheduleOptionsDropdown />
 
 		<button
-			class="h-7 rounded-md px-0.5 hover:bg-hoverLight dark:hover:bg-hoverDark"
+			class="h-7 rounded-md hover:bg-hoverLight dark:hover:bg-hoverDark"
 			title="Create new schedule"
 			on:click={createNewSchedule}
 		>

--- a/site/src/components/course-planner/course-search/ScheduleSelector.svelte
+++ b/site/src/components/course-planner/course-search/ScheduleSelector.svelte
@@ -9,7 +9,9 @@ Copyright (C) 2026 Andrew Cupps
 		AngleRightOutline,
 		PlusOutline,
 		ForwardOutline,
-		TrashBinOutline
+		TrashBinOutline,
+		LinkOutline,
+		ClipboardCheckOutline
 	} from 'flowbite-svelte-icons';
 	import {
 		CurrentScheduleStore,
@@ -22,11 +24,14 @@ Copyright (C) 2026 Andrew Cupps
 		deleteNonselectedSchedule,
 		uniqueScheduleName
 	} from '$lib/course-planner/ScheduleSelector';
+	import { encodeSchedule, SHARE_PARAM } from '$lib/course-planner/ShareLink';
+	import { base } from '$app/paths';
 	import type { ScheduleBlock, StoredSchedule } from '../../../types';
 	import PopupShare from '../../layout/PopupShare.svelte';
 
 	let dropdownOpen: boolean = false;
 	let sharePopUpOpen: boolean = false;
+	let linkCopied: boolean = false;
 
 	let currentScheduleName: string;
 	let currentScheduleSelections: ScheduleBlock[];
@@ -100,6 +105,23 @@ Copyright (C) 2026 Andrew Cupps
 			selections: currentScheduleSelections
 		});
 	}
+
+	async function copyShareLink() {
+		const token = encodeSchedule(currentScheduleSelections);
+		if (!token) {
+			// No course sections to share.
+			return;
+		}
+
+		const url = `${window.location.origin}${base}/?${SHARE_PARAM}=${token}`;
+		try {
+			await navigator.clipboard.writeText(url);
+			linkCopied = true;
+			setTimeout(() => (linkCopied = false), 1200);
+		} catch (e) {
+			console.error('Failed to copy share link:', e);
+		}
+	}
 </script>
 
 <div class="flex w-full flex-col" use:clickoutside on:clickoutside={() => (dropdownOpen = false)}>
@@ -134,6 +156,18 @@ Copyright (C) 2026 Andrew Cupps
 			on:click={createNewSchedule}
 		>
 			<PlusOutline class="h-5 w-5 px-0.5" />
+		</button>
+
+		<button
+			class="h-7 rounded-md hover:bg-hoverLight dark:hover:bg-hoverDark"
+			title={linkCopied ? 'Link copied!' : 'Copy shareable link'}
+			on:click={copyShareLink}
+		>
+			{#if linkCopied}
+				<ClipboardCheckOutline class="h-5 w-5 px-0.5" />
+			{:else}
+				<LinkOutline class="h-5 w-5 px-0.5" />
+			{/if}
 		</button>
 
 		<button

--- a/site/src/components/schedule-generator/MiniSchedule.svelte
+++ b/site/src/components/schedule-generator/MiniSchedule.svelte
@@ -5,7 +5,7 @@ https://github.com/atcupps/Jupiterp/LICENSE).
 Copyright (C) 2026 Andrew Cupps
 -->
 <script lang="ts">
-	import { schedulify } from '../../lib/course-planner/Schedule';
+	import { getClasstimeBounds, schedulify } from '../../lib/course-planner/Schedule';
 	import { getColorFromNumber } from '../../lib/course-planner/ClassMeetingUtils';
 	import { splitCourseCode } from '../../lib/course-planner/Formatting';
 	import type { Schedule, ScheduleSelection } from '../../types';
@@ -45,26 +45,14 @@ Copyright (C) 2026 Andrew Cupps
 	$: hasOther = schedule.other.length > 0;
 
 	// Time window: fit all timed meetings, with a minimum 8-hour window.
-	$: bounds = computeBounds(days);
-	function computeBounds(weekdays: Schedule[keyof Schedule][]): {
-		start: number;
-		end: number;
-	} {
-		let earliest = Number.MAX_SAFE_INTEGER;
-		let latest = Number.MIN_SAFE_INTEGER;
-		for (const day of weekdays) {
-			for (const cm of day) {
-				if (typeof cm.meeting !== 'string') {
-					earliest = Math.min(earliest, cm.meeting.classtime.start);
-					latest = Math.max(latest, cm.meeting.classtime.end);
-				}
-			}
-		}
-		if (earliest === Number.MAX_SAFE_INTEGER) {
+	$: bounds = computeBounds(schedule);
+	function computeBounds(s: Schedule): { start: number; end: number } {
+		const { earliestStart, latestEnd } = getClasstimeBounds(s);
+		if (earliestStart === Number.MAX_SAFE_INTEGER) {
 			return { start: 8, end: 16 };
 		}
-		let start = Math.floor(earliest);
-		let end = Math.ceil(latest);
+		let start = earliestStart;
+		let end = latestEnd;
 		const diff = end - start;
 		if (diff < 8) {
 			start -= Math.floor((8 - diff) / 2);

--- a/site/src/components/schedule-generator/ResultsGallery.svelte
+++ b/site/src/components/schedule-generator/ResultsGallery.svelte
@@ -60,7 +60,7 @@ Copyright (C) 2026 Andrew Cupps
 </script>
 
 <div class="flex flex-col gap-3">
-	<!-- Generate bar -->
+	<!-- Generate bar  -->
 	<div class="flex flex-row items-center gap-3">
 		<button
 			class="rounded-lg bg-orange px-4 py-1.5 font-semibold text-white

--- a/site/src/components/schedule-generator/ResultsGallery.svelte
+++ b/site/src/components/schedule-generator/ResultsGallery.svelte
@@ -16,6 +16,7 @@ Copyright (C) 2026 Andrew Cupps
 	import {
 		GenerationStateStore,
 		GeneratorRequirementsStore,
+		GeneratorSortChosenByUserStore,
 		GeneratorSortStore,
 		type GenerationState,
 		type GeneratorRequirement
@@ -55,6 +56,7 @@ Copyright (C) 2026 Andrew Cupps
 	}));
 
 	function setSort(value: string) {
+		GeneratorSortChosenByUserStore.set(true);
 		GeneratorSortStore.set(value as SortCriterion);
 	}
 </script>

--- a/site/src/lib/course-planner/CourseLoad.ts
+++ b/site/src/lib/course-planner/CourseLoad.ts
@@ -18,6 +18,7 @@ import type {
 	StoredSchedule
 } from '../../types';
 import { assignColorNumbers, modernizeSelections } from './Modernization';
+import { buildSharedSelections, decodeSchedule } from './ShareLink';
 import { client } from '$lib/client';
 import { CurrentScheduleStore, NonselectedScheduleStore } from '../../stores/CoursePlannerStores';
 
@@ -293,4 +294,79 @@ export async function ensureUpToDateAndSetStores(
 			};
 		})
 	);
+}
+
+/**
+ * Reconstruct the course selections encoded in a share token by fetching the
+ * latest course data. Returns `[]` if the token is empty, unparseable, or the
+ * course fetch fails — callers should treat that as "nothing to share".
+ * @param param The raw `s` query parameter from a shared link.
+ */
+async function loadSharedSelections(param: string): Promise<ScheduleSelection[]> {
+	const pairs = decodeSchedule(param);
+	if (pairs.length === 0) {
+		return [];
+	}
+
+	const courseCodes = new Set(pairs.map((p) => p.courseCode));
+	let courses: Record<string, Course>;
+	try {
+		courses = await getUpToDateCourses(courseCodes);
+	} catch (e) {
+		console.error('Failed to load shared schedule course data:', e);
+		return [];
+	}
+
+	return buildSharedSelections(pairs, courses);
+}
+
+/**
+ * The first "Shared schedule" name not already taken, so opening multiple
+ * shared links counts up (Shared schedule, Shared schedule 2, …).
+ */
+function uniqueSharedName(existing: StoredSchedule[]): string {
+	const taken = new Set(existing.map((s) => s.scheduleName));
+	if (!taken.has('Shared schedule')) {
+		return 'Shared schedule';
+	}
+	let n = 2;
+	while (taken.has(`Shared schedule ${n}`)) {
+		n++;
+	}
+	return `Shared schedule ${n}`;
+}
+
+/**
+ * Apply a shared schedule (from a `?s=` link) as a new named schedule, keeping
+ * the user's existing schedules intact by demoting them to non-selected ones.
+ * If the token yields no valid sections, falls back to the normal load so the
+ * user's own schedules still appear.
+ * @param param The raw `s` query parameter from a shared link.
+ * @param existingCurrent The active schedule read from local storage.
+ * @param existingNonselected The saved schedules read from local storage.
+ */
+export async function applySharedScheduleToStores(
+	param: string,
+	existingCurrent: StoredSchedule,
+	existingNonselected: StoredSchedule[]
+) {
+	const shared = await loadSharedSelections(param);
+	if (shared.length === 0) {
+		// Nothing valid to load; behave like a normal page load.
+		await ensureUpToDateAndSetStores(existingCurrent, existingNonselected);
+		return;
+	}
+
+	// Preserve the user's existing active schedule alongside their saved ones.
+	const preserved =
+		existingCurrent.selections.length > 0
+			? [existingCurrent, ...existingNonselected]
+			: existingNonselected;
+
+	CurrentScheduleStore.set({
+		scheduleName: uniqueSharedName(preserved),
+		selections: assignColorNumbers(shared)
+	});
+
+	NonselectedScheduleStore.set(preserved);
 }

--- a/site/src/lib/course-planner/CourseLoad.ts
+++ b/site/src/lib/course-planner/CourseLoad.ts
@@ -297,30 +297,6 @@ export async function ensureUpToDateAndSetStores(
 }
 
 /**
- * Reconstruct the course selections encoded in a share token by fetching the
- * latest course data. Returns `[]` if the token is empty, unparseable, or the
- * course fetch fails — callers should treat that as "nothing to share".
- * @param param The raw `s` query parameter from a shared link.
- */
-async function loadSharedSelections(param: string): Promise<ScheduleSelection[]> {
-	const pairs = decodeSchedule(param);
-	if (pairs.length === 0) {
-		return [];
-	}
-
-	const courseCodes = new Set(pairs.map((p) => p.courseCode));
-	let courses: Record<string, Course>;
-	try {
-		courses = await getUpToDateCourses(courseCodes);
-	} catch (e) {
-		console.error('Failed to load shared schedule course data:', e);
-		return [];
-	}
-
-	return buildSharedSelections(pairs, courses);
-}
-
-/**
  * The first "Shared schedule" name not already taken, so opening multiple
  * shared links counts up (Shared schedule, Shared schedule 2, …).
  */
@@ -341,6 +317,10 @@ function uniqueSharedName(existing: StoredSchedule[]): string {
  * the user's existing schedules intact by demoting them to non-selected ones.
  * If the token yields no valid sections, falls back to the normal load so the
  * user's own schedules still appear.
+ *
+ * @returns `true` if the share param was consumed (the caller should strip it),
+ *          or `false` if a transient course-data fetch failed (the caller should
+ *          keep the param so a refresh can retry the import).
  * @param param The raw `s` query parameter from a shared link.
  * @param existingCurrent The active schedule read from local storage.
  * @param existingNonselected The saved schedules read from local storage.
@@ -349,12 +329,32 @@ export async function applySharedScheduleToStores(
 	param: string,
 	existingCurrent: StoredSchedule,
 	existingNonselected: StoredSchedule[]
-) {
-	const shared = await loadSharedSelections(param);
-	if (shared.length === 0) {
-		// Nothing valid to load; behave like a normal page load.
+): Promise<boolean> {
+	const pairs = decodeSchedule(param);
+	if (pairs.length === 0) {
+		// Empty or unparseable token: nothing to retry. Load the user's own
+		// schedules and let the caller drop the useless param.
 		await ensureUpToDateAndSetStores(existingCurrent, existingNonselected);
-		return;
+		return true;
+	}
+
+	let courses: Record<string, Course>;
+	try {
+		courses = await getUpToDateCourses(new Set(pairs.map((p) => p.courseCode)));
+	} catch (e) {
+		console.error('Failed to load shared schedule course data:', e);
+		// Transient failure: show the user's own schedules but keep the param so
+		// a refresh can retry the import.
+		await ensureUpToDateAndSetStores(existingCurrent, existingNonselected);
+		return false;
+	}
+
+	const shared = buildSharedSelections(pairs, courses);
+	if (shared.length === 0) {
+		// Decoded and fetched fine, but none of the sections still exist.
+		// Nothing to retry — drop the param.
+		await ensureUpToDateAndSetStores(existingCurrent, existingNonselected);
+		return true;
 	}
 
 	// Preserve the user's existing active schedule alongside their saved ones.
@@ -369,4 +369,5 @@ export async function applySharedScheduleToStores(
 	});
 
 	NonselectedScheduleStore.set(preserved);
+	return true;
 }

--- a/site/src/lib/course-planner/CourseLoad.ts
+++ b/site/src/lib/course-planner/CourseLoad.ts
@@ -18,6 +18,7 @@ import type {
 	StoredSchedule
 } from '../../types';
 import { assignColorNumbers, modernizeSelections } from './Modernization';
+import { uniqueNumberedName } from './ScheduleSelector';
 import { buildSharedSelections, decodeSchedule } from './ShareLink';
 import { client } from '$lib/client';
 import { CurrentScheduleStore, NonselectedScheduleStore } from '../../stores/CoursePlannerStores';
@@ -219,6 +220,35 @@ async function getUpToDateCourses(courseCodes: Set<string>): Promise<Record<stri
 	return courseRecord;
 }
 
+/**
+ * Reconcile stored selections against up-to-date course data: refresh each
+ * course selection via `diffAndUpdate` (dropping ones whose course or section
+ * no longer exists) and pass UserEvents through untouched.
+ */
+function updateSelections(
+	selections: ScheduleBlock[],
+	upToDateCourses: Record<string, Course>
+): ScheduleBlock[] {
+	const updatedSelections: ScheduleBlock[] = [];
+	selections.forEach((selection) => {
+		// Push UserEvents through without updates
+		if (!('course' in selection)) {
+			updatedSelections.push(selection);
+			return;
+		}
+		const upToDate: Course = upToDateCourses[selection.course.courseCode];
+		if (!upToDate) {
+			// Course no longer exists, skip
+			return;
+		}
+		const updated = diffAndUpdate(selection, upToDate);
+		if (updated !== null) {
+			updatedSelections.push(updated);
+		}
+	});
+	return updatedSelections;
+}
+
 export async function ensureUpToDateAndSetStores(
 	current: StoredSchedule,
 	nonselected: StoredSchedule[]
@@ -238,78 +268,19 @@ export async function ensureUpToDateAndSetStores(
 		return;
 	}
 
-	const updatedCurrentSelections: ScheduleBlock[] = [];
-	current.selections.forEach((selection) => {
-		// Push UserEvents through without updates
-		if (!('course' in selection)) {
-			updatedCurrentSelections.push(selection);
-			return;
-		}
-		const upToDate: Course = upToDateCourses[selection.course.courseCode];
-		if (!upToDate) {
-			// Course no longer exists, skip
-			return;
-		}
-		const updated = diffAndUpdate(selection, upToDate);
-		if (updated !== null) {
-			updatedCurrentSelections.push(updated);
-		}
-	});
-
-	const updatedNonSelectedSchedules: StoredSchedule[] = [];
-	nonselected.forEach((stored) => {
-		const updatedSelections: ScheduleBlock[] = [];
-		stored.selections.forEach((selection) => {
-			// Push UserEvents through without updates
-			if (!('course' in selection)) {
-				updatedSelections.push(selection);
-				return;
-			}
-			const upToDate: Course = upToDateCourses[selection.course.courseCode];
-			if (!upToDate) {
-				// Course no longer exists, skip
-				return;
-			}
-			const updated = diffAndUpdate(selection, upToDate);
-			if (updated !== null) {
-				updatedSelections.push(updated);
-			}
-		});
-		updatedNonSelectedSchedules.push({
-			scheduleName: stored.scheduleName,
-			selections: updatedSelections
-		});
-	});
-
 	CurrentScheduleStore.set({
 		scheduleName: current.scheduleName,
-		selections: assignColorNumbers(updatedCurrentSelections)
+		selections: assignColorNumbers(updateSelections(current.selections, upToDateCourses))
 	});
 
 	NonselectedScheduleStore.set(
-		updatedNonSelectedSchedules.map((stored) => {
+		nonselected.map((stored) => {
 			return {
 				scheduleName: stored.scheduleName,
-				selections: assignColorNumbers(stored.selections)
+				selections: assignColorNumbers(updateSelections(stored.selections, upToDateCourses))
 			};
 		})
 	);
-}
-
-/**
- * The first "Shared schedule" name not already taken, so opening multiple
- * shared links counts up (Shared schedule, Shared schedule 2, …).
- */
-function uniqueSharedName(existing: StoredSchedule[]): string {
-	const taken = new Set(existing.map((s) => s.scheduleName));
-	if (!taken.has('Shared schedule')) {
-		return 'Shared schedule';
-	}
-	let n = 2;
-	while (taken.has(`Shared schedule ${n}`)) {
-		n++;
-	}
-	return `Shared schedule ${n}`;
 }
 
 /**
@@ -338,9 +309,15 @@ export async function applySharedScheduleToStores(
 		return true;
 	}
 
+	// Fetch the shared schedule's courses together with the user's own, so
+	// the preserved schedules get the same up-to-date reconciliation a normal
+	// (non-shared) load performs.
+	const coursesToRetrieve = getCoursesToRetrieve(existingCurrent, existingNonselected);
+	pairs.forEach((p) => coursesToRetrieve.add(p.courseCode));
+
 	let courses: Record<string, Course>;
 	try {
-		courses = await getUpToDateCourses(new Set(pairs.map((p) => p.courseCode)));
+		courses = await getUpToDateCourses(coursesToRetrieve);
 	} catch (e) {
 		console.error('Failed to load shared schedule course data:', e);
 		// Transient failure: show the user's own schedules but keep the param so
@@ -357,14 +334,21 @@ export async function applySharedScheduleToStores(
 		return true;
 	}
 
-	// Preserve the user's existing active schedule alongside their saved ones.
-	const preserved =
+	// Preserve the user's existing active schedule alongside their saved ones,
+	// reconciled against current course data like any other load.
+	const preserved = (
 		existingCurrent.selections.length > 0
 			? [existingCurrent, ...existingNonselected]
-			: existingNonselected;
+			: existingNonselected
+	).map((stored) => {
+		return {
+			scheduleName: stored.scheduleName,
+			selections: assignColorNumbers(updateSelections(stored.selections, courses))
+		};
+	});
 
 	CurrentScheduleStore.set({
-		scheduleName: uniqueSharedName(preserved),
+		scheduleName: uniqueNumberedName('Shared schedule', preserved),
 		selections: assignColorNumbers(shared)
 	});
 

--- a/site/src/lib/course-planner/Formatting.ts
+++ b/site/src/lib/course-planner/Formatting.ts
@@ -48,7 +48,7 @@ export function formatClasstime(time: Classtime): string {
  * @returns A string representation of the credit range
  */
 export function formatCredits(minCredits: number, maxCredits: number | null): string {
-	if (maxCredits !== null) {
+	if (maxCredits !== null && maxCredits !== minCredits) {
 		return minCredits + ' - ' + maxCredits;
 	} else {
 		return minCredits.toString();

--- a/site/src/lib/course-planner/SchedulePersistence.ts
+++ b/site/src/lib/course-planner/SchedulePersistence.ts
@@ -1,0 +1,53 @@
+/**
+ * This file is part of Jupiterp. For terms of use, please see the file
+ * called LICENSE at the top level of the Jupiterp source tree (online at
+ * https://github.com/atcupps/Jupiterp/LICENSE).
+ * Copyright (C) 2026 Andrew Cupps
+ *
+ * @fileoverview The planner's local-storage contract: the keys and
+ * serialization for the active schedule and the saved (non-selected)
+ * schedules. Everything that reads or writes planner state in local storage
+ * (the planner page itself, the schedule generator's "Apply") must go through
+ * this module so the format only exists in one place.
+ */
+
+import type { ScheduleBlock, StoredSchedule } from '../../types';
+import { resolveSelections, resolveStoredSchedules } from './CourseLoad';
+
+const SELECTED_SECTIONS_KEY = 'selectedSections';
+const SCHEDULE_NAME_KEY = 'scheduleName';
+const NONSELECTED_SCHEDULES_KEY = 'nonselectedSchedules';
+
+/**
+ * Serialize schedule blocks for storage, dropping transient hover previews.
+ */
+export function jsonifySections(sections: ScheduleBlock[]): string {
+	return JSON.stringify(sections.filter((s) => !('course' in s) || !s.hover));
+}
+
+/** Write the active schedule (selections and name) to local storage. */
+export function saveCurrentSchedule(schedule: StoredSchedule): void {
+	const sections = jsonifySections(schedule.selections);
+	localStorage.setItem(SELECTED_SECTIONS_KEY, sections);
+	localStorage.setItem(SCHEDULE_NAME_KEY, schedule.scheduleName);
+}
+
+/** Write the saved (non-selected) schedules to local storage. */
+export function saveNonselectedSchedules(schedules: StoredSchedule[]): void {
+	localStorage.setItem(NONSELECTED_SCHEDULES_KEY, JSON.stringify(schedules));
+}
+
+/** Read and modernize the active schedule from local storage. */
+export function readStoredCurrentSchedule(): StoredSchedule {
+	const rawSelections = localStorage.getItem(SELECTED_SECTIONS_KEY);
+	return {
+		scheduleName: localStorage.getItem(SCHEDULE_NAME_KEY) ?? 'Schedule 1',
+		selections: rawSelections ? resolveSelections(rawSelections) : []
+	};
+}
+
+/** Read and modernize the saved (non-selected) schedules from local storage. */
+export function readStoredNonselectedSchedules(): StoredSchedule[] {
+	const raw = localStorage.getItem(NONSELECTED_SCHEDULES_KEY);
+	return raw ? resolveStoredSchedules(raw) : [];
+}

--- a/site/src/lib/course-planner/ScheduleSelector.ts
+++ b/site/src/lib/course-planner/ScheduleSelector.ts
@@ -41,6 +41,31 @@ export function uniqueScheduleName(
 }
 
 /**
+ * The first numbered name of the form `base`, `base 2`, `base 3`, … not taken
+ * by an existing schedule. With `alwaysNumber`, counting starts at `base 1`
+ * and the bare `base` is never used.
+ *
+ * @param base The name to uniquify, e.g. "Shared schedule"
+ * @param existing The schedules whose names are already taken
+ * @param alwaysNumber Whether the first candidate is `base 1` instead of `base`
+ */
+export function uniqueNumberedName(
+	base: string,
+	existing: StoredSchedule[],
+	alwaysNumber: boolean = false
+): string {
+	const taken = new Set(existing.map((s) => s.scheduleName));
+	if (!alwaysNumber && !taken.has(base)) {
+		return base;
+	}
+	let n = alwaysNumber ? 1 : 2;
+	while (taken.has(`${base} ${n}`)) {
+		n++;
+	}
+	return `${base} ${n}`;
+}
+
+/**
  * Delete a specific schedule from an array of non-selected schedules.
  * @param schedule The schedule to be deleted
  * @param nonselectedSchedules The array from which to delete `schedule`.

--- a/site/src/lib/course-planner/ShareLink.test.ts
+++ b/site/src/lib/course-planner/ShareLink.test.ts
@@ -70,9 +70,9 @@ function course(courseCode: string, sectionCodes: string[]): Course {
 }
 
 describe('encodeSchedule', () => {
-	test('encodes course sections with a version prefix', () => {
-		const token = encodeSchedule([selection('CMSC131', '0101'), selection('MATH140', '0501')]);
-		expect(token).toBe('1~CMSC131-0101.MATH140-0501');
+	test('emits the current schema version prefix', () => {
+		const token = encodeSchedule([selection('CMSC131', '0101')]);
+		expect(token.startsWith('2~')).toBe(true);
 	});
 
 	test('returns empty string when there are no course sections', () => {
@@ -86,35 +86,85 @@ describe('encodeSchedule', () => {
 			selection('ENGL101', '0301', true),
 			userEvent() as unknown as ScheduleBlock
 		];
-		expect(encodeSchedule(blocks)).toBe('1~CMSC131-0101');
+		expect(decodeSchedule(encodeSchedule(blocks))).toEqual([
+			{ courseCode: 'CMSC131', sectionCode: '0101' }
+		]);
 	});
 
 	test('output uses only URL-unreserved characters', () => {
-		const token = encodeSchedule([selection('CMSC351H', '9901')]);
+		const token = encodeSchedule([selection('CMSC351H', '9901'), selection('MATH140', '0501')]);
 		expect(token).toMatch(/^[A-Za-z0-9\-._~]+$/);
+	});
+
+	test('packs standard codes shorter than the literal form', () => {
+		const blocks = [
+			selection('CMSC131', '0101'),
+			selection('MATH140', '0501'),
+			selection('ENGL101', '0301'),
+			selection('HIST200', '0201')
+		];
+		const literalLength = `1~${blocks
+			.map((b) => `${b.course.courseCode}-${b.section.sectionCode}`)
+			.join('.')}`.length;
+		expect(encodeSchedule(blocks).length).toBeLessThan(literalLength);
+	});
+});
+
+describe('encode/decode round-trip (v2)', () => {
+	test.each([
+		['CMSC131', '0101'],
+		['MATH140', '0501'],
+		['CMSC351H', '9901'], // 1-letter suffix
+		['BMGT110', '0000'], // all-zero section
+		['PHYS161', '9999'] // max section
+	])('packs and unpacks %s-%s exactly', (courseCode, sectionCode) => {
+		const token = encodeSchedule([selection(courseCode, sectionCode)]);
+		expect(decodeSchedule(token)).toEqual([{ courseCode, sectionCode }]);
+	});
+
+	test('round-trips a multi-course schedule in order', () => {
+		const pairs: [string, string][] = [
+			['CMSC131', '0101'],
+			['MATH140', '0501'],
+			['ENGL101', '0301']
+		];
+		const token = encodeSchedule(pairs.map(([c, s]) => selection(c, s)));
+		expect(decodeSchedule(token)).toEqual(
+			pairs.map(([c, s]) => ({ courseCode: c, sectionCode: s }))
+		);
+	});
+
+	test('falls back to a literal segment for non-standard codes and round-trips', () => {
+		// 4-digit number, and a lettered section: neither is packable.
+		const token = encodeSchedule([selection('AASP1000', 'FC01'), selection('CMSC131', '0101')]);
+		expect(token).toContain('AASP1000-FC01');
+		expect(decodeSchedule(token)).toEqual([
+			{ courseCode: 'AASP1000', sectionCode: 'FC01' },
+			{ courseCode: 'CMSC131', sectionCode: '0101' }
+		]);
 	});
 });
 
 describe('decodeSchedule', () => {
-	test('round-trips with encodeSchedule', () => {
-		const blocks = [selection('CMSC131', '0101'), selection('MATH140', '0501')];
-		expect(decodeSchedule(encodeSchedule(blocks))).toEqual([
+	test('still decodes legacy v1 (literal) links', () => {
+		expect(decodeSchedule('1~CMSC131-0101.MATH140-0501')).toEqual([
 			{ courseCode: 'CMSC131', sectionCode: '0101' },
 			{ courseCode: 'MATH140', sectionCode: '0501' }
 		]);
 	});
 
 	test('rejects an unknown schema version', () => {
-		expect(decodeSchedule('2~CMSC131-0101')).toEqual([]);
+		expect(decodeSchedule('9~CMSC131-0101')).toEqual([]);
 	});
 
 	test('returns empty for empty or malformed input', () => {
 		expect(decodeSchedule('')).toEqual([]);
 		expect(decodeSchedule('CMSC131-0101')).toEqual([]);
 		expect(decodeSchedule('1~')).toEqual([]);
+		expect(decodeSchedule('2~')).toEqual([]);
 	});
 
-	test('skips unparseable pairs but keeps valid ones', () => {
+	test('skips unparseable v1 segments but keeps valid ones', () => {
 		expect(decodeSchedule('1~CMSC131-0101.garbage.MATH140-0501')).toEqual([
 			{ courseCode: 'CMSC131', sectionCode: '0101' },
 			{ courseCode: 'MATH140', sectionCode: '0501' }

--- a/site/src/lib/course-planner/ShareLink.test.ts
+++ b/site/src/lib/course-planner/ShareLink.test.ts
@@ -1,0 +1,159 @@
+/**
+ * This file is part of Jupiterp. For terms of use, please see the file
+ * called LICENSE at the top level of the Jupiterp source tree (online at
+ * https://github.com/atcupps/Jupiterp/LICENSE).
+ * Copyright (C) 2026 Andrew Cupps
+ *
+ * @fileoverview Unit tests for ShareLink.ts
+ */
+
+import { describe, expect, test } from '@jest/globals';
+import type { Course } from '@jupiterp/jupiterp';
+import { buildSharedSelections, decodeSchedule, encodeSchedule } from './ShareLink';
+import type { ScheduleBlock, ScheduleSelection, UserEvent } from '../../types';
+
+/** Minimal `ScheduleSelection` for encoding tests. */
+function selection(courseCode: string, sectionCode: string, hover = false): ScheduleSelection {
+	return {
+		course: { courseCode } as ScheduleSelection['course'],
+		section: { sectionCode } as ScheduleSelection['section'],
+		hover,
+		differences: {
+			instructors: false,
+			numMeetings: false,
+			meetingType: false,
+			meetingTime: false,
+			meetingLocation: false
+		},
+		colorNumber: 0
+	};
+}
+
+/** Minimal `UserEvent` for encoding tests. */
+function userEvent(): UserEvent {
+	return {
+		id: 'e1',
+		name: 'Lunch',
+		days: ['M'],
+		startTime: 12,
+		endTime: 13,
+		location: '',
+		notes: '',
+		colorNumber: 0
+	};
+}
+
+/** Minimal `Course` with sections for reconstruction tests. */
+function course(courseCode: string, sectionCodes: string[]): Course {
+	return {
+		courseCode,
+		name: `${courseCode} Name`,
+		minCredits: 3,
+		maxCredits: null,
+		genEds: null,
+		conditions: null,
+		description: 'desc',
+		sections: sectionCodes.map(
+			(sectionCode) =>
+				({
+					courseCode,
+					sectionCode,
+					instructors: ['Prof X'],
+					meetings: [],
+					openSeats: 0,
+					totalSeats: 0,
+					waitlist: 0,
+					holdfile: null
+				}) as NonNullable<Course['sections']>[number]
+		)
+	};
+}
+
+describe('encodeSchedule', () => {
+	test('encodes course sections with a version prefix', () => {
+		const token = encodeSchedule([selection('CMSC131', '0101'), selection('MATH140', '0501')]);
+		expect(token).toBe('1~CMSC131-0101.MATH140-0501');
+	});
+
+	test('returns empty string when there are no course sections', () => {
+		expect(encodeSchedule([])).toBe('');
+		expect(encodeSchedule([userEvent() as unknown as ScheduleBlock])).toBe('');
+	});
+
+	test('excludes hover previews and custom events', () => {
+		const blocks: ScheduleBlock[] = [
+			selection('CMSC131', '0101'),
+			selection('ENGL101', '0301', true),
+			userEvent() as unknown as ScheduleBlock
+		];
+		expect(encodeSchedule(blocks)).toBe('1~CMSC131-0101');
+	});
+
+	test('output uses only URL-unreserved characters', () => {
+		const token = encodeSchedule([selection('CMSC351H', '9901')]);
+		expect(token).toMatch(/^[A-Za-z0-9\-._~]+$/);
+	});
+});
+
+describe('decodeSchedule', () => {
+	test('round-trips with encodeSchedule', () => {
+		const blocks = [selection('CMSC131', '0101'), selection('MATH140', '0501')];
+		expect(decodeSchedule(encodeSchedule(blocks))).toEqual([
+			{ courseCode: 'CMSC131', sectionCode: '0101' },
+			{ courseCode: 'MATH140', sectionCode: '0501' }
+		]);
+	});
+
+	test('rejects an unknown schema version', () => {
+		expect(decodeSchedule('2~CMSC131-0101')).toEqual([]);
+	});
+
+	test('returns empty for empty or malformed input', () => {
+		expect(decodeSchedule('')).toEqual([]);
+		expect(decodeSchedule('CMSC131-0101')).toEqual([]);
+		expect(decodeSchedule('1~')).toEqual([]);
+	});
+
+	test('skips unparseable pairs but keeps valid ones', () => {
+		expect(decodeSchedule('1~CMSC131-0101.garbage.MATH140-0501')).toEqual([
+			{ courseCode: 'CMSC131', sectionCode: '0101' },
+			{ courseCode: 'MATH140', sectionCode: '0501' }
+		]);
+	});
+});
+
+describe('buildSharedSelections', () => {
+	const courses: Record<string, Course> = {
+		CMSC131: course('CMSC131', ['0101', '0201']),
+		MATH140: course('MATH140', ['0501'])
+	};
+
+	test('reconstructs selections in order with sequential color numbers', () => {
+		const built = buildSharedSelections(
+			[
+				{ courseCode: 'CMSC131', sectionCode: '0101' },
+				{ courseCode: 'MATH140', sectionCode: '0501' }
+			],
+			courses
+		);
+		expect(built.map((s) => s.course.courseCode)).toEqual(['CMSC131', 'MATH140']);
+		expect(built.map((s) => s.section.sectionCode)).toEqual(['0101', '0501']);
+		expect(built.map((s) => s.colorNumber)).toEqual([0, 1]);
+		expect(built[0].hover).toBe(false);
+		expect(built[0].differences.instructors).toBe(false);
+	});
+
+	test('skips pairs whose course or section no longer exists', () => {
+		const built = buildSharedSelections(
+			[
+				{ courseCode: 'CMSC131', sectionCode: '9999' }, // missing section
+				{ courseCode: 'BMGT110', sectionCode: '0101' }, // missing course
+				{ courseCode: 'MATH140', sectionCode: '0501' } // valid
+			],
+			courses
+		);
+		expect(built).toHaveLength(1);
+		expect(built[0].course.courseCode).toBe('MATH140');
+		expect(built[0].colorNumber).toBe(0);
+	});
+});

--- a/site/src/lib/course-planner/ShareLink.ts
+++ b/site/src/lib/course-planner/ShareLink.ts
@@ -16,23 +16,93 @@ import type { Course } from '@jupiterp/jupiterp';
 import type { CourseSectionPair, ScheduleBlock, ScheduleSelection } from '../../types';
 import { noDifferences } from './Schedule';
 
-/** Query parameter that carries a shared schedule, e.g. `?s=1~CMSC131-0101`. */
+/** Query parameter that carries a shared schedule, e.g. `?s=2~CMSC4Aq8z`. */
 export const SHARE_PARAM = 's';
 
 /**
- * Schema version of the encoded token. Bump this if the encoding format
- * changes so old links can still be recognized (and rejected gracefully).
+ * Schema version emitted by `encodeSchedule`. `decodeSchedule` understands
+ * every version listed below, so links shared under an older format keep
+ * working after a bump.
+ *
+ * - `1` — readable literal pairs: `1~CMSC131-0101.MATH140-0501`
+ * - `2` — dept letters + a base62-packed number/section token (this version)
  */
-const SCHEMA_VERSION = '1';
+const SCHEMA_VERSION = '2';
 
-/** Separates encoded course/section pairs from each other. */
+/** Separates encoded course segments from each other. */
 const PAIR_SEPARATOR = '.';
 
-/** Separates a courseCode from a sectionCode within a single pair. */
+/** Separates a courseCode from a sectionCode in a literal (fallback) segment. */
 const FIELD_SEPARATOR = '-';
 
 /** Separates the schema version from the payload. */
 const VERSION_SEPARATOR = '~';
+
+/**
+ * Base62 alphabet (URL-unreserved, and notably free of `-`, which lets the v2
+ * decoder tell a packed segment apart from a literal `course-section` one).
+ */
+const BASE62 = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+
+/**
+ * Width of a packed token. A course packs into 29 bits (10 number + 5 suffix +
+ * 14 section), and 62^5 comfortably covers that, so every packed token is
+ * exactly 5 chars — which is what lets the decoder split dept (everything
+ * before) from the packed value (the last 5 chars) without a delimiter.
+ */
+const PACKED_WIDTH = 5;
+
+// Bit layout of a packed course: [ number:10 | suffix:5 | section:14 ].
+const SECTION_BITS = 14;
+const SUFFIX_BITS = 5;
+
+/** Matches a "standard" course code: dept letters, a 3-digit number, optional 1-letter suffix. */
+const PACKABLE_COURSE = /^([A-Za-z]+)(\d{3})([A-Za-z]?)$/;
+
+/** A packable section is exactly four digits, e.g. `0101`. */
+const PACKABLE_SECTION = /^\d{4}$/;
+
+/** Encode `n` as a fixed-width base62 string (left-padded with `0`s). */
+function toBase62(n: number, width: number): string {
+	let out = '';
+	for (let i = 0; i < width; i++) {
+		out = BASE62[n % 62] + out;
+		n = Math.floor(n / 62);
+	}
+	return out;
+}
+
+/** Decode a base62 string, or return `-1` if it contains an invalid character. */
+function fromBase62(s: string): number {
+	let n = 0;
+	for (const ch of s) {
+		const digit = BASE62.indexOf(ch);
+		if (digit === -1) {
+			return -1;
+		}
+		n = n * 62 + digit;
+	}
+	return n;
+}
+
+/**
+ * Encode one selection as the shortest segment that round-trips exactly:
+ * `DEPT` + a 5-char packed token for standard codes, or the literal
+ * `courseCode-sectionCode` for anything that doesn't fit the packable shape
+ * (4-digit numbers, lettered sections, etc.).
+ */
+function encodeSegment(courseCode: string, sectionCode: string): string {
+	const course = PACKABLE_COURSE.exec(courseCode);
+	if (course && PACKABLE_SECTION.test(sectionCode)) {
+		const dept = course[1];
+		const number = parseInt(course[2], 10);
+		const suffix = course[3] ? course[3].toUpperCase().charCodeAt(0) - 64 : 0; // A=1..Z=26
+		const section = parseInt(sectionCode, 10);
+		const packed = (number << (SUFFIX_BITS + SECTION_BITS)) | (suffix << SECTION_BITS) | section;
+		return dept + toBase62(packed, PACKED_WIDTH);
+	}
+	return `${courseCode}${FIELD_SEPARATOR}${sectionCode}`;
+}
 
 /**
  * Encode a schedule's course selections into a compact, URL-safe token.
@@ -42,27 +112,91 @@ const VERSION_SEPARATOR = '~';
  * characters, so it never needs percent-encoding.
  *
  * @param selections The schedule blocks to encode.
- * @returns A token like `1~CMSC131-0101.MATH140-0501`, or `''` if there are
- *          no course sections to share.
+ * @returns A token like `2~CMSC4Aq8z.MATH...`, or `''` if there are no course
+ *          sections to share.
  */
 export function encodeSchedule(selections: ScheduleBlock[]): string {
-	const pairs = selections
+	const segments = selections
 		.filter((s): s is ScheduleSelection => 'course' in s && !s.hover)
-		.map((s) => `${s.course.courseCode}${FIELD_SEPARATOR}${s.section.sectionCode}`);
+		.map((s) => encodeSegment(s.course.courseCode, s.section.sectionCode));
 
-	if (pairs.length === 0) {
+	if (segments.length === 0) {
 		return '';
 	}
 
-	return `${SCHEMA_VERSION}${VERSION_SEPARATOR}${pairs.join(PAIR_SEPARATOR)}`;
+	return `${SCHEMA_VERSION}${VERSION_SEPARATOR}${segments.join(PAIR_SEPARATOR)}`;
+}
+
+/** Decode a literal `courseCode-sectionCode` segment, or `null` if malformed. */
+function decodeLiteralSegment(token: string): CourseSectionPair | null {
+	// Course codes never contain `-`, so the last `-` splits course/section.
+	const split = token.lastIndexOf(FIELD_SEPARATOR);
+	if (split <= 0 || split === token.length - 1) {
+		return null;
+	}
+	return {
+		courseCode: token.slice(0, split),
+		sectionCode: token.slice(split + 1)
+	};
+}
+
+/** Decode a `DEPT` + packed-token segment, or `null` if malformed. */
+function decodePackedSegment(token: string): CourseSectionPair | null {
+	const dept = token.slice(0, -PACKED_WIDTH);
+	if (!dept) {
+		return null;
+	}
+	const packed = fromBase62(token.slice(-PACKED_WIDTH));
+	if (packed < 0) {
+		return null;
+	}
+
+	const number = (packed >> (SUFFIX_BITS + SECTION_BITS)) & 0x3ff; // 10 bits
+	const suffix = (packed >> SECTION_BITS) & 0x1f; // 5 bits
+	const section = packed & 0x3fff; // 14 bits
+	const suffixLetter = suffix >= 1 && suffix <= 26 ? String.fromCharCode(64 + suffix) : '';
+
+	return {
+		courseCode: dept + String(number).padStart(3, '0') + suffixLetter,
+		sectionCode: String(section).padStart(4, '0')
+	};
+}
+
+/** v1 payload: literal pairs only. */
+function decodeV1(payload: string): CourseSectionPair[] {
+	const pairs: CourseSectionPair[] = [];
+	for (const token of payload.split(PAIR_SEPARATOR)) {
+		const pair = decodeLiteralSegment(token);
+		if (pair) {
+			pairs.push(pair);
+		}
+	}
+	return pairs;
+}
+
+/** v2 payload: a segment with `-` is literal; otherwise it is packed. */
+function decodeV2(payload: string): CourseSectionPair[] {
+	const pairs: CourseSectionPair[] = [];
+	for (const token of payload.split(PAIR_SEPARATOR)) {
+		const pair = token.includes(FIELD_SEPARATOR)
+			? decodeLiteralSegment(token)
+			: token.length > PACKED_WIDTH
+				? decodePackedSegment(token)
+				: null;
+		if (pair) {
+			pairs.push(pair);
+		}
+	}
+	return pairs;
 }
 
 /**
  * Decode a share token back into the course/section pairs it represents.
  *
  * Tolerant of malformed input: an unrecognized version or any unparseable
- * token yields `[]` (or skips just that pair) rather than throwing, so a
+ * segment yields `[]` (or skips just that segment) rather than throwing, so a
  * broken or truncated link degrades gracefully instead of crashing load.
+ * Older schema versions still decode, so previously-shared links keep working.
  *
  * @param param The raw token from the `s` query parameter.
  * @returns The decoded `CourseSectionPair[]` (possibly empty).
@@ -73,29 +207,23 @@ export function decodeSchedule(param: string): CourseSectionPair[] {
 	}
 
 	const versionEnd = param.indexOf(VERSION_SEPARATOR);
-	if (versionEnd === -1 || param.slice(0, versionEnd) !== SCHEMA_VERSION) {
+	if (versionEnd === -1) {
 		return [];
 	}
 
+	const version = param.slice(0, versionEnd);
 	const payload = param.slice(versionEnd + 1);
 	if (!payload) {
 		return [];
 	}
 
-	const pairs: CourseSectionPair[] = [];
-	for (const token of payload.split(PAIR_SEPARATOR)) {
-		// Course codes never contain `-`, so the last `-` splits course/section.
-		const split = token.lastIndexOf(FIELD_SEPARATOR);
-		if (split <= 0 || split === token.length - 1) {
-			continue;
-		}
-		pairs.push({
-			courseCode: token.slice(0, split),
-			sectionCode: token.slice(split + 1)
-		});
+	if (version === '1') {
+		return decodeV1(payload);
 	}
-
-	return pairs;
+	if (version === '2') {
+		return decodeV2(payload);
+	}
+	return [];
 }
 
 /**

--- a/site/src/lib/course-planner/ShareLink.ts
+++ b/site/src/lib/course-planner/ShareLink.ts
@@ -1,0 +1,149 @@
+/**
+ * This file is part of Jupiterp. For terms of use, please see the file
+ * called LICENSE at the top level of the Jupiterp source tree (online at
+ * https://github.com/atcupps/Jupiterp/LICENSE).
+ * Copyright (C) 2026 Andrew Cupps
+ *
+ * @fileoverview Encodes and decodes a schedule as a short, shareable URL
+ * token ("permalink"). A schedule is fully reconstructable from an ordered
+ * list of (courseCode, sectionCode) pairs; all other section data is
+ * re-fetched live from the API when the link is opened. These functions are
+ * pure (no API / `$lib` imports) so they can be unit tested directly; the
+ * data-fetching reconstruction lives in `CourseLoad.ts`.
+ */
+
+import type { Course } from '@jupiterp/jupiterp';
+import type { CourseSectionPair, ScheduleBlock, ScheduleSelection } from '../../types';
+import { noDifferences } from './Schedule';
+
+/** Query parameter that carries a shared schedule, e.g. `?s=1~CMSC131-0101`. */
+export const SHARE_PARAM = 's';
+
+/**
+ * Schema version of the encoded token. Bump this if the encoding format
+ * changes so old links can still be recognized (and rejected gracefully).
+ */
+const SCHEMA_VERSION = '1';
+
+/** Separates encoded course/section pairs from each other. */
+const PAIR_SEPARATOR = '.';
+
+/** Separates a courseCode from a sectionCode within a single pair. */
+const FIELD_SEPARATOR = '-';
+
+/** Separates the schema version from the payload. */
+const VERSION_SEPARATOR = '~';
+
+/**
+ * Encode a schedule's course selections into a compact, URL-safe token.
+ *
+ * Only real (non-preview) course sections are included; custom `UserEvent`s
+ * are intentionally excluded. The token uses only RFC 3986 "unreserved"
+ * characters, so it never needs percent-encoding.
+ *
+ * @param selections The schedule blocks to encode.
+ * @returns A token like `1~CMSC131-0101.MATH140-0501`, or `''` if there are
+ *          no course sections to share.
+ */
+export function encodeSchedule(selections: ScheduleBlock[]): string {
+	const pairs = selections
+		.filter((s): s is ScheduleSelection => 'course' in s && !s.hover)
+		.map((s) => `${s.course.courseCode}${FIELD_SEPARATOR}${s.section.sectionCode}`);
+
+	if (pairs.length === 0) {
+		return '';
+	}
+
+	return `${SCHEMA_VERSION}${VERSION_SEPARATOR}${pairs.join(PAIR_SEPARATOR)}`;
+}
+
+/**
+ * Decode a share token back into the course/section pairs it represents.
+ *
+ * Tolerant of malformed input: an unrecognized version or any unparseable
+ * token yields `[]` (or skips just that pair) rather than throwing, so a
+ * broken or truncated link degrades gracefully instead of crashing load.
+ *
+ * @param param The raw token from the `s` query parameter.
+ * @returns The decoded `CourseSectionPair[]` (possibly empty).
+ */
+export function decodeSchedule(param: string): CourseSectionPair[] {
+	if (!param) {
+		return [];
+	}
+
+	const versionEnd = param.indexOf(VERSION_SEPARATOR);
+	if (versionEnd === -1 || param.slice(0, versionEnd) !== SCHEMA_VERSION) {
+		return [];
+	}
+
+	const payload = param.slice(versionEnd + 1);
+	if (!payload) {
+		return [];
+	}
+
+	const pairs: CourseSectionPair[] = [];
+	for (const token of payload.split(PAIR_SEPARATOR)) {
+		// Course codes never contain `-`, so the last `-` splits course/section.
+		const split = token.lastIndexOf(FIELD_SEPARATOR);
+		if (split <= 0 || split === token.length - 1) {
+			continue;
+		}
+		pairs.push({
+			courseCode: token.slice(0, split),
+			sectionCode: token.slice(split + 1)
+		});
+	}
+
+	return pairs;
+}
+
+/**
+ * Reconstruct full `ScheduleSelection`s from decoded pairs and freshly-fetched
+ * course data. Pairs whose course or section no longer exist are silently
+ * skipped, so a stale link still opens whatever is still valid. Selections are
+ * built directly from the live section (with `noDifferences()`) so the opened
+ * schedule never shows a spurious "section changed" warning.
+ *
+ * This is pure: the caller is responsible for fetching `courses`.
+ *
+ * @param pairs Decoded course/section pairs, in display order.
+ * @param courses Up-to-date course data keyed by course code.
+ * @returns The reconstructed selections (color numbers assigned by index).
+ */
+export function buildSharedSelections(
+	pairs: CourseSectionPair[],
+	courses: Record<string, Course>
+): ScheduleSelection[] {
+	const result: ScheduleSelection[] = [];
+
+	pairs.forEach((pair) => {
+		const course = courses[pair.courseCode];
+		if (!course || !course.sections) {
+			return;
+		}
+
+		const section = course.sections.find((s) => s.sectionCode === pair.sectionCode);
+		if (!section) {
+			return;
+		}
+
+		result.push({
+			course: {
+				courseCode: course.courseCode,
+				name: course.name,
+				minCredits: course.minCredits,
+				maxCredits: course.maxCredits,
+				description: course.description,
+				genEds: course.genEds,
+				conditions: course.conditions
+			},
+			section,
+			hover: false,
+			differences: noDifferences(),
+			colorNumber: result.length
+		});
+	});
+
+	return result;
+}

--- a/site/src/lib/schedule-generator/ApplySchedule.ts
+++ b/site/src/lib/schedule-generator/ApplySchedule.ts
@@ -6,46 +6,19 @@
  *
  * @fileoverview Applies a generated schedule to the course planner. The
  * planner reads its state from local storage on mount, so this writes there
- * directly (in the planner's format), saving the generated schedule as a new
- * named schedule and preserving the user's existing schedules.
+ * (through the planner's shared persistence layer), saving the generated
+ * schedule as a new named schedule and preserving the user's existing
+ * schedules.
  */
 
-import { resolveSelections, resolveStoredSchedules } from '../course-planner/CourseLoad';
-import { assignColorNumbers } from '../course-planner/Modernization';
+import {
+	readStoredCurrentSchedule,
+	readStoredNonselectedSchedules,
+	saveCurrentSchedule,
+	saveNonselectedSchedules
+} from '../course-planner/SchedulePersistence';
+import { uniqueNumberedName } from '../course-planner/ScheduleSelector';
 import type { GeneratedSchedule } from './types';
-import type { ScheduleBlock, StoredSchedule } from '../../types';
-
-const SELECTIONS_KEY = 'selectedSections';
-const NAME_KEY = 'scheduleName';
-const NONSELECTED_KEY = 'nonselectedSchedules';
-
-/** Read the planner's current schedule from local storage. */
-function readCurrentSchedule(): StoredSchedule {
-	const rawSelections = localStorage.getItem(SELECTIONS_KEY);
-	const selections: ScheduleBlock[] = rawSelections ? resolveSelections(rawSelections) : [];
-	const scheduleName = localStorage.getItem(NAME_KEY) ?? 'Schedule 1';
-	return { scheduleName, selections };
-}
-
-/** Read the planner's non-selected schedules from local storage. */
-function readNonselectedSchedules(): StoredSchedule[] {
-	const raw = localStorage.getItem(NONSELECTED_KEY);
-	return raw ? resolveStoredSchedules(raw) : [];
-}
-
-/**
- * The first "Generated N" name not already taken by an existing schedule, so
- * repeated applies count up (Generated 1, Generated 2, …) rather than stacking
- * a prefix.
- */
-function uniqueGeneratedName(existing: StoredSchedule[]): string {
-	const taken = new Set(existing.map((s) => s.scheduleName));
-	let n = 1;
-	while (taken.has(`Generated ${n}`)) {
-		n++;
-	}
-	return `Generated ${n}`;
-}
 
 /**
  * Save `schedule` into the planner as a new named schedule (e.g. "Generated
@@ -53,21 +26,19 @@ function uniqueGeneratedName(existing: StoredSchedule[]): string {
  * any selections. Returns the name assigned to the new schedule.
  */
 export function applyGeneratedSchedule(schedule: GeneratedSchedule): string {
-	const current = readCurrentSchedule();
-	const nonselected = readNonselectedSchedules();
+	const current = readStoredCurrentSchedule();
+	const nonselected = readStoredNonselectedSchedules();
 
 	// Preserve the existing active schedule alongside the others.
 	const preserved = current.selections.length > 0 ? [current, ...nonselected] : nonselected;
 
 	// Name the new schedule against what is actually being kept, so a discarded
 	// empty active schedule never forces an unnecessary suffix.
-	const name = uniqueGeneratedName(preserved);
+	const name = uniqueNumberedName('Generated', preserved, true);
 
-	const selections = assignColorNumbers(schedule.selections);
-
-	localStorage.setItem(SELECTIONS_KEY, JSON.stringify(selections));
-	localStorage.setItem(NAME_KEY, name);
-	localStorage.setItem(NONSELECTED_KEY, JSON.stringify(preserved));
+	// The engine already assigned each selection its color number.
+	saveCurrentSchedule({ scheduleName: name, selections: schedule.selections });
+	saveNonselectedSchedules(preserved);
 
 	return name;
 }

--- a/site/src/lib/schedule-generator/Generate.ts
+++ b/site/src/lib/schedule-generator/Generate.ts
@@ -18,6 +18,7 @@ import {
 	GenerationStateStore,
 	GeneratorConstraintsStore,
 	GeneratorRequirementsStore,
+	GeneratorSortChosenByUserStore,
 	GeneratorSortStore,
 	type GeneratorRequirement,
 	type RelaxationHint
@@ -132,8 +133,9 @@ export async function runGeneration(): Promise<void> {
 		const result = generate(requests, constraints, ratings);
 
 		if (result.schedules.length > 0) {
-			// With optional courses in play, lead with the fullest schedules.
-			if (requests.some((r) => !r.required)) {
+			// With optional courses in play, lead with the fullest schedules —
+			// but never override a sort the user picked themselves.
+			if (requests.some((r) => !r.required) && !get(GeneratorSortChosenByUserStore)) {
 				GeneratorSortStore.set('mostClasses');
 			}
 			GenerationStateStore.set({

--- a/site/src/lib/schedule-generator/GeneratorFormat.ts
+++ b/site/src/lib/schedule-generator/GeneratorFormat.ts
@@ -58,35 +58,6 @@ export function timeSlotOptions(
 	return options;
 }
 
-/** Format minutes-since-midnight as a 24-hour `<input type="time">` value. */
-export function minutesToTimeInput(minutes: number | null): string {
-	if (minutes === null) {
-		return '';
-	}
-	const hh = Math.floor(minutes / 60)
-		.toString()
-		.padStart(2, '0');
-	const mm = (minutes % 60).toString().padStart(2, '0');
-	return `${hh}:${mm}`;
-}
-
-/** Parse an `<input type="time">` value ("HH:MM") to minutes, or null. */
-export function timeInputToMinutes(value: string): number | null {
-	if (!value) {
-		return null;
-	}
-	const parts = value.split(':');
-	if (parts.length !== 2) {
-		return null;
-	}
-	const hours = parseInt(parts[0], 10);
-	const minutes = parseInt(parts[1], 10);
-	if (Number.isNaN(hours) || Number.isNaN(minutes)) {
-		return null;
-	}
-	return hours * 60 + minutes;
-}
-
 /** A short, human-readable label for an overridden per-section filter. */
 export function overriddenFilterLabel(filter: OverriddenFilter): string {
 	switch (filter) {

--- a/site/src/lib/schedule-generator/ScheduleGenerator.ts
+++ b/site/src/lib/schedule-generator/ScheduleGenerator.ts
@@ -352,7 +352,9 @@ export function generate(
 
 	const found: Candidate[][] = [];
 	const chosen: Candidate[] = [];
-	const placedSlots: MinuteSlot[] = [];
+	// Placed slots bucketed by day: slotsConflict requires matching days, so
+	// each candidate slot only needs to be checked against its own day.
+	const placedSlotsByDay = new Map<EngineDay, MinuteSlot[]>();
 	let nodes = 0;
 	let truncated = false;
 	const minCredits = constraints.minCredits;
@@ -379,20 +381,29 @@ export function generate(
 				truncated = true;
 				return;
 			}
-			const conflicts = candidate.slots.some((slot) =>
-				placedSlots.some((placed) => slotsConflict(slot, placed, constraints.minGapMinutes))
-			);
+			const conflicts = candidate.slots.some((slot) => {
+				const sameDay = placedSlotsByDay.get(slot.day);
+				return (
+					sameDay !== undefined &&
+					sameDay.some((placed) => slotsConflict(slot, placed, constraints.minGapMinutes))
+				);
+			});
 			if (conflicts) {
 				continue;
 			}
 			chosen.push(candidate);
 			for (const slot of candidate.slots) {
-				placedSlots.push(slot);
+				const bucket = placedSlotsByDay.get(slot.day);
+				if (bucket) {
+					bucket.push(slot);
+				} else {
+					placedSlotsByDay.set(slot.day, [slot]);
+				}
 			}
 			dfs(courseIndex + 1);
 			chosen.pop();
-			for (let k = 0; k < candidate.slots.length; k++) {
-				placedSlots.pop();
+			for (const slot of candidate.slots) {
+				placedSlotsByDay.get(slot.day)?.pop();
 			}
 			if (truncated) {
 				return;

--- a/site/src/lib/schedule-generator/ScheduleSorter.test.ts
+++ b/site/src/lib/schedule-generator/ScheduleSorter.test.ts
@@ -77,6 +77,13 @@ describe('sortedByCriterion', () => {
 		expect(sorted[0]).toBe(early);
 	});
 
+	test('earliest end puts untimed last', () => {
+		const timed = withMetrics({ latestEndMinutes: 14 * 60 });
+		const untimed = withMetrics({ latestEndMinutes: null });
+		const sorted = sortedByCriterion([untimed, timed], 'earliestEnd');
+		expect(sorted).toEqual([timed, untimed]);
+	});
+
 	test('most credits sorts by max credits descending', () => {
 		const light = withMetrics({ maxCredits: 12 });
 		const heavy = withMetrics({ maxCredits: 17 });

--- a/site/src/lib/schedule-generator/ScheduleSorter.ts
+++ b/site/src/lib/schedule-generator/ScheduleSorter.ts
@@ -76,8 +76,9 @@ function comparatorFor(criterion: SortCriterion): Comparator {
 				byDesc(ratingOrUnrated)
 			);
 		case 'earliestEnd':
+			// No timed meetings means there is no "finish" to rank; sort last.
 			return chain(
-				byAsc((s) => s.metrics.latestEndMinutes ?? 0),
+				byAsc((s) => s.metrics.latestEndMinutes ?? Number.MAX_SAFE_INTEGER),
 				byDesc(ratingOrUnrated)
 			);
 		case 'mostCredits':

--- a/site/src/routes/+page.svelte
+++ b/site/src/routes/+page.svelte
@@ -10,10 +10,12 @@ Copyright (C) 2026 Andrew Cupps
 	import CourseSearch from '../components/course-planner/course-search/CourseSearch.svelte';
 	import { onMount } from 'svelte';
 	import {
+		applySharedScheduleToStores,
 		ensureUpToDateAndSetStores,
 		resolveSelections,
 		resolveStoredSchedules
 	} from '../lib/course-planner/CourseLoad';
+	import { SHARE_PARAM } from '$lib/course-planner/ShareLink';
 	import { loadInstructorLookup } from '$lib/course-planner/CourseSearch';
 	import { handlePlannerShortcutKeydown } from '../lib/course-planner/PlannerShortcuts';
 	import {
@@ -123,11 +125,22 @@ Copyright (C) 2026 Andrew Cupps
 					storedNonselectedSchedules = [];
 				}
 
-				// Find differences between stored selections and
-				// most up-to-date course data, and update accordingly.
-				ensureUpToDateAndSetStores(currentSchedule, storedNonselectedSchedules);
-
+				// Allow store subscriptions to persist whatever we load below.
 				hasReadLocalStorage = true;
+
+				// If the page was opened from a shared link, load that schedule
+				// as a new named schedule (preserving the user's own), then
+				// strip the param so a refresh doesn't re-import it.
+				const shareParam = new URLSearchParams(window.location.search).get(SHARE_PARAM);
+				if (shareParam) {
+					applySharedScheduleToStores(shareParam, currentSchedule, storedNonselectedSchedules);
+					const cleanUrl = window.location.pathname + window.location.hash;
+					window.history.replaceState(window.history.state, '', cleanUrl);
+				} else {
+					// Find differences between stored selections and
+					// most up-to-date course data, and update accordingly.
+					ensureUpToDateAndSetStores(currentSchedule, storedNonselectedSchedules);
+				}
 			}
 		} catch (e) {
 			console.log('Unable to retrieve courses: ' + e);

--- a/site/src/routes/+page.svelte
+++ b/site/src/routes/+page.svelte
@@ -133,9 +133,20 @@ Copyright (C) 2026 Andrew Cupps
 				// strip the param so a refresh doesn't re-import it.
 				const shareParam = new URLSearchParams(window.location.search).get(SHARE_PARAM);
 				if (shareParam) {
-					applySharedScheduleToStores(shareParam, currentSchedule, storedNonselectedSchedules);
-					const cleanUrl = window.location.pathname + window.location.hash;
-					window.history.replaceState(window.history.state, '', cleanUrl);
+					(async () => {
+						const consumed = await applySharedScheduleToStores(
+							shareParam,
+							currentSchedule,
+							storedNonselectedSchedules
+						);
+						if (consumed) {
+							// Strip the param so a refresh doesn't re-import; on a
+							// transient fetch failure (consumed === false) keep it so
+							// a refresh can retry.
+							const cleanUrl = window.location.pathname + window.location.hash;
+							window.history.replaceState(window.history.state, '', cleanUrl);
+						}
+					})().catch((e) => console.error('Failed to apply shared schedule:', e));
 				} else {
 					// Find differences between stored selections and
 					// most up-to-date course data, and update accordingly.

--- a/site/src/routes/+page.svelte
+++ b/site/src/routes/+page.svelte
@@ -11,10 +11,14 @@ Copyright (C) 2026 Andrew Cupps
 	import { onMount } from 'svelte';
 	import {
 		applySharedScheduleToStores,
-		ensureUpToDateAndSetStores,
-		resolveSelections,
-		resolveStoredSchedules
+		ensureUpToDateAndSetStores
 	} from '../lib/course-planner/CourseLoad';
+	import {
+		readStoredCurrentSchedule,
+		readStoredNonselectedSchedules,
+		saveCurrentSchedule,
+		saveNonselectedSchedules
+	} from '../lib/course-planner/SchedulePersistence';
 	import { SHARE_PARAM } from '$lib/course-planner/ShareLink';
 	import { loadInstructorLookup } from '$lib/course-planner/CourseSearch';
 	import { handlePlannerShortcutKeydown } from '../lib/course-planner/PlannerShortcuts';
@@ -24,7 +28,7 @@ Copyright (C) 2026 Andrew Cupps
 		DepartmentsStore
 	} from '../stores/CoursePlannerStores';
 	import { client } from '$lib/client';
-	import type { ScheduleBlock, StoredSchedule } from '../types';
+	import type { StoredSchedule } from '../types';
 	import IsDesktop from '../components/course-planner/IsDesktop.svelte';
 	import { PlannerState } from '../stores/CoursePlannerStores';
 
@@ -61,8 +65,7 @@ Copyright (C) 2026 Andrew Cupps
 			// Save to local storage
 			if (currentSchedule) {
 				if (typeof window !== 'undefined') {
-					localStorage.setItem('selectedSections', jsonifySections(currentSchedule.selections));
-					localStorage.setItem('scheduleName', currentSchedule.scheduleName);
+					saveCurrentSchedule(currentSchedule);
 				}
 			}
 		}
@@ -77,7 +80,7 @@ Copyright (C) 2026 Andrew Cupps
 			// Save to local storage
 			if (nonselectedSchedules) {
 				if (typeof window !== 'undefined') {
-					localStorage.setItem('nonselectedSchedules', JSON.stringify(nonselectedSchedules));
+					saveNonselectedSchedules(nonselectedSchedules);
 				}
 			}
 		}
@@ -93,37 +96,9 @@ Copyright (C) 2026 Andrew Cupps
 		// Retrieve data from client local storage
 		try {
 			if (typeof window !== 'undefined') {
-				// Get stored selections from local storage
-				const storedSelectionsOption = localStorage.getItem('selectedSections');
-				let storedSelections: ScheduleBlock[];
-				if (storedSelectionsOption) {
-					storedSelections = resolveSelections(storedSelectionsOption);
-				} else {
-					storedSelections = [];
-				}
-
-				// Get stored current schedule name from local storage
-				const storedScheduleNameOption = localStorage.getItem('scheduleName');
-				let storedScheduleName: string;
-				if (storedScheduleNameOption) {
-					storedScheduleName = storedScheduleNameOption;
-				} else {
-					storedScheduleName = 'Schedule 1';
-				}
-
-				const currentSchedule: StoredSchedule = {
-					scheduleName: storedScheduleName,
-					selections: storedSelections
-				};
-
-				// Get stored non-selected schedules from local storage
-				const storedNonselectedSchedulesOption = localStorage.getItem('nonselectedSchedules');
-				let storedNonselectedSchedules: StoredSchedule[];
-				if (storedNonselectedSchedulesOption) {
-					storedNonselectedSchedules = resolveStoredSchedules(storedNonselectedSchedulesOption);
-				} else {
-					storedNonselectedSchedules = [];
-				}
+				// Get the stored current and non-selected schedules
+				const currentSchedule: StoredSchedule = readStoredCurrentSchedule();
+				const storedNonselectedSchedules: StoredSchedule[] = readStoredNonselectedSchedules();
 
 				// Allow store subscriptions to persist whatever we load below.
 				hasReadLocalStorage = true;
@@ -162,10 +137,6 @@ Copyright (C) 2026 Andrew Cupps
 			NonselectedScheduleStore.set([]);
 		}
 	});
-
-	function jsonifySections(sections: ScheduleBlock[]): string {
-		return JSON.stringify(sections.filter((s) => !('course' in s) || !s.hover));
-	}
 
 	function handlePlannerKeydown(event: KeyboardEvent) {
 		handlePlannerShortcutKeydown(event, isDesktop);

--- a/site/src/stores/GeneratorStores.ts
+++ b/site/src/stores/GeneratorStores.ts
@@ -67,6 +67,13 @@ export const GeneratorConstraintsStore: Writable<HardConstraints> = writable(def
 /** The criterion by which results are currently ranked. */
 export const GeneratorSortStore: Writable<SortCriterion> = writable('bestRating');
 
+/**
+ * Whether the user has explicitly picked a sort criterion. While false,
+ * a generation run with optional courses may switch the sort to
+ * "most classes"; once true, the user's choice is never overridden.
+ */
+export const GeneratorSortChosenByUserStore: Writable<boolean> = writable(false);
+
 /** The current generation state. */
 export const GenerationStateStore: Writable<GenerationState> = writable({
 	kind: 'idle'


### PR DESCRIPTION
Depends on #932 for no reason in particular (Merge #932 to reduce the size of this)

## Additions
- Encoded link in the format of https://jupiterp.com/?s=2~CMSC4Aq8z.MATH8nP2k.ENGL1xR0w

Shareable portion:
2 ~ segment . segment . segment …
- pair separator '.'
- one course per segment
- version separator '~'
- (2) schema version

Segment: 
CMSC131, section 0101
  ↓
dept = "CMSC" 
packed 29-bit integer = [ number:10 | suffix:5 | section:14 ]
                        = [   131    |   0      |   101    ]
                        
- Button to get link
- Tests for the link working

## Changes
- Dead code from schedule generator removed