### PR TITLE
Reorganize schedule options into three dropdowns

### DIFF
--- a/site/src/components/course-planner/course-search/ScheduleAddDropdown.svelte
+++ b/site/src/components/course-planner/course-search/ScheduleAddDropdown.svelte
@@ -5,36 +5,36 @@ https://github.com/atcupps/Jupiterp/LICENSE).
 Copyright (C) 2026 Andrew Cupps
  -->
 <script lang="ts">
-	import { Dropdown, DropdownItem } from "flowbite-svelte";
-	import { PlusOutline } from "flowbite-svelte-icons";
+	import { Dropdown, DropdownItem } from 'flowbite-svelte';
+	import { PlusOutline } from 'flowbite-svelte-icons';
 
-    let dropdownOpen = false;
-    
-    export let newScheduleFunction;
-    export let newCustomEventFunction;
+	let dropdownOpen = false;
+
+	export let newScheduleFunction;
+	export let newCustomEventFunction;
 </script>
 
 <button
-	class="rounded-md h-7 hover:bg-hoverLight dark:hover:bg-hoverDark"
+	class="h-7 rounded-md hover:bg-hoverLight dark:hover:bg-hoverDark"
 	title="New schedule or event"
 >
 	<PlusOutline class="h-5 w-5 px-0.5" />
 </button>
 
 <Dropdown class="w-32 rounded-md bg-bgLight dark:bg-divBorderDark" bind:open={dropdownOpen}>
-    <DropdownItem
-            class="flex items-center justify-start px-2 hover:bg-hoverLight dark:hover:bg-hoverDark"
-            title="Create a new schedule"
-            on:click={newScheduleFunction}
-        >
-            New Schedule
-    </DropdownItem>
+	<DropdownItem
+		class="flex items-center justify-start px-2 hover:bg-hoverLight dark:hover:bg-hoverDark"
+		title="Create a new schedule"
+		on:click={newScheduleFunction}
+	>
+		New Schedule
+	</DropdownItem>
 
-    <DropdownItem
-            class="flex items-center justify-start px-2 hover:bg-hoverLight dark:hover:bg-hoverDark"
-            title="Add custom event to schedule"
-            on:click={newCustomEventFunction}
-        >
-            Add Custom Event
-    </DropdownItem>
+	<DropdownItem
+		class="flex items-center justify-start px-2 hover:bg-hoverLight dark:hover:bg-hoverDark"
+		title="Add custom event to schedule"
+		on:click={newCustomEventFunction}
+	>
+		Add Custom Event
+	</DropdownItem>
 </Dropdown>

--- a/site/src/components/course-planner/course-search/ScheduleAddDropdown.svelte
+++ b/site/src/components/course-planner/course-search/ScheduleAddDropdown.svelte
@@ -1,0 +1,40 @@
+<!-- 
+This file is part of Jupiterp. For terms of use, please see the file
+called LICENSE at the top level of the Jupiterp source tree (online at
+https://github.com/atcupps/Jupiterp/LICENSE).
+Copyright (C) 2026 Andrew Cupps
+ -->
+<script lang="ts">
+	import { Dropdown, DropdownItem } from "flowbite-svelte";
+	import { PlusOutline } from "flowbite-svelte-icons";
+
+    let dropdownOpen = false;
+    
+    export let newScheduleFunction;
+    export let newCustomEventFunction;
+</script>
+
+<button
+	class="rounded-md h-7 hover:bg-hoverLight dark:hover:bg-hoverDark"
+	title="New schedule or event"
+>
+	<PlusOutline class="h-5 w-5 px-0.5" />
+</button>
+
+<Dropdown class="w-32 rounded-md bg-bgLight dark:bg-divBorderDark" bind:open={dropdownOpen}>
+    <DropdownItem
+            class="flex items-center justify-start px-2 hover:bg-hoverLight dark:hover:bg-hoverDark"
+            title="Create a new schedule"
+            on:click={newScheduleFunction}
+        >
+            New Schedule
+    </DropdownItem>
+
+    <DropdownItem
+            class="flex items-center justify-start px-2 hover:bg-hoverLight dark:hover:bg-hoverDark"
+            title="Add custom event to schedule"
+            on:click={newCustomEventFunction}
+        >
+            Add Custom Event
+    </DropdownItem>
+</Dropdown>

--- a/site/src/components/course-planner/course-search/ScheduleOptionsDropdown.svelte
+++ b/site/src/components/course-planner/course-search/ScheduleOptionsDropdown.svelte
@@ -10,12 +10,10 @@ Copyright (C) 2026 Andrew Cupps
 		DotsVerticalOutline,
 		TrashBinOutline,
 		FileCopyOutline,
-		PlusOutline,
 		LinkOutline,
 		ClipboardCheckOutline
 	} from 'flowbite-svelte-icons';
 	import {
-		AddCustomEventStore,
 		CurrentScheduleStore,
 		NonselectedScheduleStore
 	} from '../../../stores/CoursePlannerStores';
@@ -84,11 +82,6 @@ Copyright (C) 2026 Andrew Cupps
 		});
 	}
 
-	function addCustomEvent() {
-		dropdownOpen = false;
-		AddCustomEventStore.set(true);
-	}
-
 	/**
 	 * Copy `text` to the clipboard, returning whether it succeeded. Prefers the
 	 * async Clipboard API (HTTPS / modern browsers) and falls back to a hidden
@@ -149,20 +142,13 @@ Copyright (C) 2026 Andrew Cupps
 </script>
 
 <button
-	class="rounded-md px-0.5 hover:bg-hoverLight dark:hover:bg-hoverDark"
+	class="rounded-md hover:bg-hoverLight dark:hover:bg-hoverDark"
 	title="Schedule options"
 >
 	<DotsVerticalOutline class="h-5 w-5" />
 </button>
 
 <Dropdown class="w-24 rounded-md bg-bgLight dark:bg-divBorderDark" bind:open={dropdownOpen}>
-	<DropdownItem
-		class="flex items-center justify-start px-2 hover:bg-hoverLight dark:hover:bg-hoverDark"
-		title="Add custom event to schedule"
-		on:click={addCustomEvent}
-	>
-		<PlusOutline class="z-50 mr-1 h-3 w-3" /> Add Event
-	</DropdownItem>
 
 	<DropdownItem
 		class="flex items-center justify-start

--- a/site/src/components/course-planner/course-search/ScheduleOptionsDropdown.svelte
+++ b/site/src/components/course-planner/course-search/ScheduleOptionsDropdown.svelte
@@ -167,19 +167,4 @@ Copyright (C) 2026 Andrew Cupps
 	>
 		<FileCopyOutline class="z-50 mr-1 h-3 w-3" /> Duplicate
 	</DropdownItem>
-
-	<DropdownItem
-		class="flex items-center justify-start
-                            px-2 hover:bg-hoverLight dark:hover:bg-hoverDark"
-		title="Copy a shareable link to this schedule"
-		on:click={copyShareLink}
-	>
-		{#if linkCopied}
-			<ClipboardCheckOutline class="z-50 mr-1 h-3 w-3" /> Copied!
-		{:else if linkError}
-			<LinkOutline class="z-50 mr-1 h-3 w-3" /> Copy failed
-		{:else}
-			<LinkOutline class="z-50 mr-1 h-3 w-3" /> Copy Link
-		{/if}
-	</DropdownItem>
 </Dropdown>

--- a/site/src/components/course-planner/course-search/ScheduleOptionsDropdown.svelte
+++ b/site/src/components/course-planner/course-search/ScheduleOptionsDropdown.svelte
@@ -6,25 +6,15 @@ Copyright (C) 2026 Andrew Cupps
  -->
 <script lang="ts">
 	import { Dropdown, DropdownItem } from 'flowbite-svelte';
-	import {
-		DotsVerticalOutline,
-		TrashBinOutline,
-		FileCopyOutline,
-		LinkOutline,
-		ClipboardCheckOutline
-	} from 'flowbite-svelte-icons';
+	import { DotsVerticalOutline, TrashBinOutline, FileCopyOutline } from 'flowbite-svelte-icons';
 	import {
 		CurrentScheduleStore,
 		NonselectedScheduleStore
 	} from '../../../stores/CoursePlannerStores';
 	import { uniqueScheduleName } from '$lib/course-planner/ScheduleSelector';
-	import { encodeSchedule, SHARE_PARAM } from '$lib/course-planner/ShareLink';
-	import { base } from '$app/paths';
 	import type { ScheduleBlock, StoredSchedule } from '../../../types';
 
 	let dropdownOpen = false;
-	let linkCopied = false;
-	let linkError = false;
 
 	let currentScheduleName: string;
 	let currentScheduleSelections: ScheduleBlock[];
@@ -81,75 +71,13 @@ Copyright (C) 2026 Andrew Cupps
 			selections: currentScheduleSelections
 		});
 	}
-
-	/**
-	 * Copy `text` to the clipboard, returning whether it succeeded. Prefers the
-	 * async Clipboard API (HTTPS / modern browsers) and falls back to a hidden
-	 * textarea + `execCommand('copy')` for insecure contexts and older mobile
-	 * browsers where `navigator.clipboard` is unavailable.
-	 */
-	async function copyToClipboard(text: string): Promise<boolean> {
-		if (typeof navigator !== 'undefined' && navigator.clipboard) {
-			try {
-				await navigator.clipboard.writeText(text);
-				return true;
-			} catch {
-				// Fall through to the legacy path.
-			}
-		}
-
-		try {
-			const textarea = document.createElement('textarea');
-			textarea.value = text;
-			textarea.setAttribute('readonly', '');
-			textarea.style.position = 'fixed';
-			textarea.style.opacity = '0';
-			document.body.appendChild(textarea);
-			textarea.select();
-			const ok = document.execCommand('copy');
-			document.body.removeChild(textarea);
-			return ok;
-		} catch {
-			return false;
-		}
-	}
-
-	async function copyShareLink() {
-		const token = encodeSchedule(currentScheduleSelections);
-		if (!token) {
-			// No course sections to share.
-			return;
-		}
-
-		const url = `${window.location.origin}${base}/?${SHARE_PARAM}=${token}`;
-		const copied = await copyToClipboard(url);
-		if (copied) {
-			linkError = false;
-			linkCopied = true;
-			setTimeout(() => {
-				linkCopied = false;
-				dropdownOpen = false;
-			}, 1200);
-		} else {
-			linkCopied = false;
-			linkError = true;
-			console.error('Failed to copy share link to clipboard.');
-			setTimeout(() => {
-				linkError = false;
-			}, 1800);
-		}
-	}
 </script>
 
-<button
-	class="rounded-md hover:bg-hoverLight dark:hover:bg-hoverDark"
-	title="Schedule options"
->
+<button class="rounded-md hover:bg-hoverLight dark:hover:bg-hoverDark" title="Schedule options">
 	<DotsVerticalOutline class="h-5 w-5" />
 </button>
 
 <Dropdown class="w-24 rounded-md bg-bgLight dark:bg-divBorderDark" bind:open={dropdownOpen}>
-
 	<DropdownItem
 		class="flex items-center justify-start
                             px-2 hover:bg-hoverLight dark:hover:bg-hoverDark"

--- a/site/src/components/course-planner/course-search/ScheduleSelector.svelte
+++ b/site/src/components/course-planner/course-search/ScheduleSelector.svelte
@@ -5,16 +5,9 @@ https://github.com/atcupps/Jupiterp/LICENSE).
 Copyright (C) 2026 Andrew Cupps
 -->
 <script lang="ts">
+	import { AngleRightOutline, TrashBinOutline } from 'flowbite-svelte-icons';
 	import {
-		AngleRightOutline,
-		PlusOutline,
-		ForwardOutline,
-		TrashBinOutline,
-		LinkOutline,
-		ClipboardCheckOutline
-	} from 'flowbite-svelte-icons';
-	import {
-	AddCustomEventStore,
+		AddCustomEventStore,
 		CurrentScheduleStore,
 		NonselectedScheduleStore
 	} from '../../../stores/CoursePlannerStores';
@@ -134,7 +127,6 @@ Copyright (C) 2026 Andrew Cupps
 
 <div class="flex w-full flex-col" use:clickoutside on:clickoutside={() => (dropdownOpen = false)}>
 	<div class="2xl:text-md flex w-full flex-row pb-1 text-sm" title="Toggle schedule dropdown">
-		
 		<!-- Schedule selection -->
 		<div
 			class="flex grow flex-row justify-start rounded-md px-0.5 py-1
@@ -159,7 +151,7 @@ Copyright (C) 2026 Andrew Cupps
 		</div>
 
 		<!-- Additional schedule option menu -->
-		
+
 		<ScheduleOptionsDropdown />
 
 		<ScheduleAddDropdown
@@ -170,7 +162,7 @@ Copyright (C) 2026 Andrew Cupps
 		<ScheduleShareDropdown
 			calendarExportFunction={() => (sharePopUpOpen = !sharePopUpOpen)}
 			copyShareLinkFunction={() => copyShareLink()}
-			linkCopied={linkCopied}
+			{linkCopied}
 		/>
 	</div>
 

--- a/site/src/components/course-planner/course-search/ScheduleSelector.svelte
+++ b/site/src/components/course-planner/course-search/ScheduleSelector.svelte
@@ -14,6 +14,7 @@ Copyright (C) 2026 Andrew Cupps
 		ClipboardCheckOutline
 	} from 'flowbite-svelte-icons';
 	import {
+	AddCustomEventStore,
 		CurrentScheduleStore,
 		NonselectedScheduleStore
 	} from '../../../stores/CoursePlannerStores';
@@ -28,6 +29,8 @@ Copyright (C) 2026 Andrew Cupps
 	import { base } from '$app/paths';
 	import type { ScheduleBlock, StoredSchedule } from '../../../types';
 	import PopupShare from '../../layout/PopupShare.svelte';
+	import ScheduleAddDropdown from './ScheduleAddDropdown.svelte';
+	import ScheduleShareDropdown from './ScheduleShareDropdown.svelte';
 
 	let dropdownOpen: boolean = false;
 	let sharePopUpOpen: boolean = false;
@@ -106,6 +109,11 @@ Copyright (C) 2026 Andrew Cupps
 		});
 	}
 
+	function addCustomEvent() {
+		dropdownOpen = false;
+		AddCustomEventStore.set(true);
+	}
+
 	async function copyShareLink() {
 		const token = encodeSchedule(currentScheduleSelections);
 		if (!token) {
@@ -126,6 +134,8 @@ Copyright (C) 2026 Andrew Cupps
 
 <div class="flex w-full flex-col" use:clickoutside on:clickoutside={() => (dropdownOpen = false)}>
 	<div class="2xl:text-md flex w-full flex-row pb-1 text-sm" title="Toggle schedule dropdown">
+		
+		<!-- Schedule selection -->
 		<div
 			class="flex grow flex-row justify-start rounded-md px-0.5 py-1
                     text-left hover:bg-hoverLight hover:dark:bg-hoverDark"
@@ -148,36 +158,20 @@ Copyright (C) 2026 Andrew Cupps
 			/>
 		</div>
 
+		<!-- Additional schedule option menu -->
+		
 		<ScheduleOptionsDropdown />
 
-		<button
-			class="h-7 rounded-md px-0.5 hover:bg-hoverLight dark:hover:bg-hoverDark"
-			title="Create new schedule"
-			on:click={createNewSchedule}
-		>
-			<PlusOutline class="h-5 w-5 px-0.5" />
-		</button>
+		<ScheduleAddDropdown
+			newCustomEventFunction={() => addCustomEvent()}
+			newScheduleFunction={() => createNewSchedule()}
+		/>
 
-		<button
-			class="h-7 rounded-md hover:bg-hoverLight dark:hover:bg-hoverDark"
-			title={linkCopied ? 'Link copied!' : 'Copy shareable link'}
-			on:click={copyShareLink}
-		>
-			{#if linkCopied}
-				<ClipboardCheckOutline class="h-5 w-5 px-0.5" />
-			{:else}
-				<LinkOutline class="h-5 w-5 px-0.5" />
-			{/if}
-		</button>
-
-		<button
-			class="h-7 rounded-md
-                        hover:bg-hoverLight dark:hover:bg-hoverDark"
-			title="Export schedule"
-			on:click={() => (sharePopUpOpen = !sharePopUpOpen)}
-		>
-			<ForwardOutline class="h-5 w-5 px-0.5" />
-		</button>
+		<ScheduleShareDropdown
+			calendarExportFunction={() => (sharePopUpOpen = !sharePopUpOpen)}
+			copyShareLinkFunction={() => copyShareLink()}
+			linkCopied={linkCopied}
+		/>
 	</div>
 
 	{#if dropdownOpen}

--- a/site/src/components/course-planner/course-search/ScheduleShareDropdown.svelte
+++ b/site/src/components/course-planner/course-search/ScheduleShareDropdown.svelte
@@ -5,46 +5,46 @@ https://github.com/atcupps/Jupiterp/LICENSE).
 Copyright (C) 2026 Andrew Cupps
  -->
 <script lang="ts">
-	import { Dropdown, DropdownItem } from "flowbite-svelte";
+	import { Dropdown, DropdownItem } from 'flowbite-svelte';
 	import {
-        CalendarMonthOutline,
-        ClipboardCheckOutline,
-        ForwardOutline,
-        LinkOutline
-    } from "flowbite-svelte-icons";
+		CalendarMonthOutline,
+		ClipboardCheckOutline,
+		ForwardOutline,
+		LinkOutline
+	} from 'flowbite-svelte-icons';
 
-    let dropdownOpen = false;
-    
-    export let calendarExportFunction;
-    export let copyShareLinkFunction;
-    export let linkCopied: boolean;
+	let dropdownOpen = false;
+
+	export let calendarExportFunction;
+	export let copyShareLinkFunction;
+	export let linkCopied: boolean;
 </script>
 
 <button
-	class="rounded-md h-7 hover:bg-hoverLight dark:hover:bg-hoverDark"
+	class="h-7 rounded-md hover:bg-hoverLight dark:hover:bg-hoverDark"
 	title="Share or export schedule"
 >
 	<ForwardOutline class="h-5 w-5 px-0.5" />
 </button>
 
 <Dropdown class="w-32 rounded-md bg-bgLight dark:bg-divBorderDark" bind:open={dropdownOpen}>
-    <DropdownItem
-            class="flex items-center justify-start px-2 hover:bg-hoverLight dark:hover:bg-hoverDark"
-            title="Download an .ics file to export to a calendar app"
-            on:click={calendarExportFunction}
-        >
-            <CalendarMonthOutline class="z-50 mr-1 h-3 w-3" /> Download .ics
-    </DropdownItem>
+	<DropdownItem
+		class="flex items-center justify-start px-2 hover:bg-hoverLight dark:hover:bg-hoverDark"
+		title="Download an .ics file to export to a calendar app"
+		on:click={calendarExportFunction}
+	>
+		<CalendarMonthOutline class="z-50 mr-1 h-3 w-3" /> Download .ics
+	</DropdownItem>
 
-    <DropdownItem
-            class="flex items-center justify-start px-2 hover:bg-hoverLight dark:hover:bg-hoverDark"
-            title="Create a shareable link"
-            on:click={copyShareLinkFunction}
-        >
-            {#if !linkCopied}
-                <LinkOutline class="z-50 mr-1 h-3 w-3" /> Copy Link
-            {:else}
-                <ClipboardCheckOutline class="z-50 mr-1 h-3 w-3" /> Link Copied
-            {/if}
-    </DropdownItem>
+	<DropdownItem
+		class="flex items-center justify-start px-2 hover:bg-hoverLight dark:hover:bg-hoverDark"
+		title="Create a shareable link"
+		on:click={copyShareLinkFunction}
+	>
+		{#if !linkCopied}
+			<LinkOutline class="z-50 mr-1 h-3 w-3" /> Copy Link
+		{:else}
+			<ClipboardCheckOutline class="z-50 mr-1 h-3 w-3" /> Link Copied
+		{/if}
+	</DropdownItem>
 </Dropdown>

--- a/site/src/components/course-planner/course-search/ScheduleShareDropdown.svelte
+++ b/site/src/components/course-planner/course-search/ScheduleShareDropdown.svelte
@@ -1,0 +1,50 @@
+<!-- 
+This file is part of Jupiterp. For terms of use, please see the file
+called LICENSE at the top level of the Jupiterp source tree (online at
+https://github.com/atcupps/Jupiterp/LICENSE).
+Copyright (C) 2026 Andrew Cupps
+ -->
+<script lang="ts">
+	import { Dropdown, DropdownItem } from "flowbite-svelte";
+	import {
+        CalendarMonthOutline,
+        ClipboardCheckOutline,
+        ForwardOutline,
+        LinkOutline
+    } from "flowbite-svelte-icons";
+
+    let dropdownOpen = false;
+    
+    export let calendarExportFunction;
+    export let copyShareLinkFunction;
+    export let linkCopied: boolean;
+</script>
+
+<button
+	class="rounded-md h-7 hover:bg-hoverLight dark:hover:bg-hoverDark"
+	title="Share or export schedule"
+>
+	<ForwardOutline class="h-5 w-5 px-0.5" />
+</button>
+
+<Dropdown class="w-32 rounded-md bg-bgLight dark:bg-divBorderDark" bind:open={dropdownOpen}>
+    <DropdownItem
+            class="flex items-center justify-start px-2 hover:bg-hoverLight dark:hover:bg-hoverDark"
+            title="Download an .ics file to export to a calendar app"
+            on:click={calendarExportFunction}
+        >
+            <CalendarMonthOutline class="z-50 mr-1 h-3 w-3" /> Download .ics
+    </DropdownItem>
+
+    <DropdownItem
+            class="flex items-center justify-start px-2 hover:bg-hoverLight dark:hover:bg-hoverDark"
+            title="Create a shareable link"
+            on:click={copyShareLinkFunction}
+        >
+            {#if !linkCopied}
+                <LinkOutline class="z-50 mr-1 h-3 w-3" /> Copy Link
+            {:else}
+                <ClipboardCheckOutline class="z-50 mr-1 h-3 w-3" /> Link Copied
+            {/if}
+    </DropdownItem>
+</Dropdown>


### PR DESCRIPTION
Experimentally reorganizing the UI for schedule options into three dropdown menus: one for delete/duplicate, one for adding (events or a new schedule), and one for sharing (export to ics or share link).